### PR TITLE
Add "British Chinglish" original-PDF-text question language

### DIFF
--- a/lib/i18n/languageOptions.ts
+++ b/lib/i18n/languageOptions.ts
@@ -47,8 +47,14 @@ const PENDING_LANGUAGE_OPTIONS: readonly LanguageOption[] = [
 // To enable a future language:
 // 1. Add/register its messages in messages/index.ts
 // 2. Remove its pending entry below so it becomes implemented via LOCALE_REGISTRY
+
+// The original-test pseudo-language ("British Chinglish") is pinned to the very
+// top of the picker so users can jump straight to the verbatim PDF text.
+const ORIGINAL_TEST_LANGUAGE_CODE: Locale = 'en-orig';
+
 export const LANGUAGE_OPTIONS: readonly LanguageOption[] = [
-  ...IMPLEMENTED_LANGUAGE_OPTIONS,
+  ...IMPLEMENTED_LANGUAGE_OPTIONS.filter((option) => option.code === ORIGINAL_TEST_LANGUAGE_CODE),
+  ...IMPLEMENTED_LANGUAGE_OPTIONS.filter((option) => option.code !== ORIGINAL_TEST_LANGUAGE_CODE),
   ...PENDING_LANGUAGE_OPTIONS,
 ];
 

--- a/lib/qbank/datasets.ts
+++ b/lib/qbank/datasets.ts
@@ -16,6 +16,7 @@ export const DATASETS: Record<DatasetId, DatasetConfig> = {
     url: '/qbank/2023-test1/questions.json',
     patchUrl: '/qbank/2023-test1/tags.patch.json', // ✅ new
     translationUrls: {
+      'en-orig': '/qbank/2023-test1/translations.en-orig.json',
       ja: '/qbank/2023-test1/translations.ja.json',
       ko: '/qbank/2023-test1/translations.ko.json',
       fr: '/qbank/2023-test1/translations.fr.json',

--- a/lib/qbank/localeSupport.ts
+++ b/lib/qbank/localeSupport.ts
@@ -1,6 +1,7 @@
 const BASE_QUESTION_URL = '/qbank/2023-test1/questions.json';
 
 const PRODUCTION_TRANSLATION_URLS: Record<string, string> = {
+  'en-orig': '/qbank/2023-test1/translations.en-orig.json',
   ko: '/qbank/2023-test1/translations.ko.json',
   ja: '/qbank/2023-test1/translations.ja.json',
   fr: '/qbank/2023-test1/translations.fr.json',
@@ -9,6 +10,7 @@ const PRODUCTION_TRANSLATION_URLS: Record<string, string> = {
 };
 
 const TRANSLATION_NOTICE_LABELS: Record<string, string> = {
+  'en-orig': 'Original PDF (British Chinglish)',
   ko: 'Korean',
   ja: 'Japanese',
   fr: 'French',
@@ -30,7 +32,10 @@ export function hasProductionQuestionTranslations(locale: string | null | undefi
 
 export function isTranslatedOnlyQuestionLocale(locale: string | null | undefined): boolean {
   const normalized = normalizeLocale(locale);
-  if (normalized === 'ja') return true;
+  // ja (partial translation) and en-orig (only the 969 questions that exist in the
+  // source PDF) intentionally show ONLY their translated questions, in every build —
+  // so British Chinglish drops the 35 master questions that aren't in the PDF.
+  if (normalized === 'ja' || normalized === 'en-orig') return true;
   return isDevelopmentVisibilityEnabled() && hasProductionQuestionTranslations(normalized);
 }
 

--- a/lib/qbank/rowDisplay.ts
+++ b/lib/qbank/rowDisplay.ts
@@ -17,6 +17,10 @@ const ROW_DISPLAY_LABELS: Record<Locale, { right: string; wrong: string }> = {
     right: 'Vrai',
     wrong: 'Faux',
   },
+  'en-orig': {
+    right: 'Right',
+    wrong: 'Wrong',
+  },
 };
 
 export function getRowDisplayLabel(

--- a/messages/index.ts
+++ b/messages/index.ts
@@ -32,6 +32,13 @@ export const LOCALE_REGISTRY = {
     label: 'Français',
     messages: fr,
   },
+  // British Chinglish: the verbatim pre-correction PDF extract, surfaced as a
+  // selectable question language. UI chrome stays English (reuses `en` messages);
+  // only the qbank question/option text differs (see translations.en-orig.json).
+  'en-orig': {
+    label: 'British Chinglish, (original test version)',
+    messages: en,
+  },
 } as const satisfies Record<string, LocaleDefinition>;
 
 export type Locale = keyof typeof LOCALE_REGISTRY;

--- a/public/qbank/2023-test1/translations.en-orig.json
+++ b/public/qbank/2023-test1/translations.en-orig.json
@@ -1,0 +1,10719 @@
+{
+  "meta": {
+    "locale": "en-orig",
+    "label": "British Chinglish, (original test version)",
+    "description": "Verbatim original question text extracted from the text layer of \"2023 Driving test 1.pdf\". Answers inherited from the English master qbank (some PDF-staged answers are wrong). Mapped 1:1 to master by question number; master questions not present in this PDF fall back to English.",
+    "source": {
+      "pdf": "2023 Driving test 1.pdf",
+      "method": "pdfplumber text-layer, column reading-order"
+    },
+    "translatedQuestions": 969,
+    "generatedAt": "2026-06-04T11:24:42.179581+00:00",
+    "localeAnswerKeySupport": true
+  },
+  "questions": {
+    "q0001": {
+      "prompt": "When braking on a muddy road, the tires can easily spin or drift and cause traffic accidents.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0002": {
+      "prompt": "When a vehicle runs on an expressway at the speed of 100 kilometers per hour, its safe distance from the vehicle in front is not less than 100 meters.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0003": {
+      "prompt": "A vehicle running on an expressway may frequently change lanes.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0004": {
+      "prompt": "When a vehicle changes lane, the driver should turn on the turn signal in advance,observe traffic conditions, maintain a safe distance and move into the new lane.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0005": {
+      "prompt": "When an accident has caused congestion on an expressway, the vehicles may run in the emergency strip on the right or in the shoulder of the road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0006": {
+      "prompt": "After a vehicle enters a mountain road, it should pay special attention to the continuous curves sign. In addition, it should voluntarily evade vehicles and pedestrians, reduce speed in a time manner and honk in advance.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0007": {
+      "prompt": "When passing a dangerous section of a mountain road, especially by the locations of frequent occurrence of landslides, mudslides, the driver should drive with care and avoid stopping.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0008": {
+      "prompt": "In the course of reversing, the driver should move slowly, observe the conditions on both sides and in the rear and be ready to stop anytime.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0009": {
+      "prompt": "In a vehicle that has safety belts, the driver should request the passengers to buckle up.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0010": {
+      "prompt": "A vehicle is not allowed to make a U turn on the ramp of an expressway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0011": {
+      "prompt": "When passing a section of a mountain road which is prone to landside and mudflow, the driver should not stop.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0012": {
+      "prompt": "The three principles for careful driving are concentration, careful observation and early prevention.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0013": {
+      "prompt": "When a vehicle changes lane, the driver should turn on the turn signal and rapidly enter the new lane.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0014": {
+      "prompt": "If a vehicle may encounter a vehicle coming in the opposite direction in the course of overtaking, the driver should speed up in advance and overtake.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0015": {
+      "prompt": "When a vehicle stops for a long time, the driver should select a car park to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0016": {
+      "prompt": "When a vehicle passes a school or a residential area, the driver should observe the signs and markings, go slowly and refrain from honking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0017": {
+      "prompt": "When driving at night, the driver should reduce speed and go forward if the vehicle coming in the opposite direction fails to turn off the high beam light. This is designed to prevent an accident from happening when there are pedestrians crossing the place where the lights of the two vehicles meet.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0018": {
+      "prompt": "When a driver suddenly encounters a vehicle in the opposite direction that forces its way by overtaking and occupying his lane, the driver may refuse to avoid it and force it to yield to you.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0019": {
+      "prompt": "When crossing each other on a narrow road, the driver should slow down, yield and stop first.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0020": {
+      "prompt": "If discovering pedestrians abruptly cross the road while driving, the driver should immediately reduce speed and evade.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0021": {
+      "prompt": "When there’s a diversion traffic control on the expressway, a driver can stop by the side to wait instead of leaving out of the expressway, for continually running after the traffic control.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0022": {
+      "prompt": "When driving in a snowy day, the driver should drive along the vehicle tracks if there are any.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0023": {
+      "prompt": "After a tire blows out and before the driver can control the speed of the vehicle, he should refrain from using the foot brake to stop the vehicle. Otherwise, a horizontal swing of the vehicle can cause greater danger.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0024": {
+      "prompt": "When driving in icy and snowy weather, light reflection from the accumulated snow can easily make a driver feel dizzy and have an illusion.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0025": {
+      "prompt": "When passing through an overflowing road, a high gear should be used to pass rapidly.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0026": {
+      "prompt": "When a vehicle passes a tunnel, it is prohibited from overtaking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0027": {
+      "prompt": "When a vehicle passes a level crossing, the driver should use the low gear to pass and should not change gear halfway in order to avoid engine kill.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0028": {
+      "prompt": "When bicycles ahead obstruct the traffic flow, the driver may honk to remind them, speed up and bypass.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0029": {
+      "prompt": "A driver should stop on the expressway at once to have a rest when he feel tired.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0030": {
+      "prompt": "When a vehicle goes down a long slope, it should run at a lower gear and fully use the engine to brake.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0031": {
+      "prompt": "As the traffic flow at an interchange is generally one-way, the vehicles do not have to reduce speed when passing.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0032": {
+      "prompt": "When the vehicles cross each other at night, the driver may continuous change lights to remind the vehicle coming in the opposite direction and at the same should reduce speed and go forward or stop on the right side.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0033": {
+      "prompt": "When driving in a heavy rain, the driver should control the speed to avoid the danger arising from water slide.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0034": {
+      "prompt": "When driving, the driver should be courteous and defensive, instead of being offensive.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0035": {
+      "prompt": "When a vehicle passes a level crossing, it is prohibited from overtaking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0036": {
+      "prompt": "When a vehicle runs on an expressway, the driver may ascertain the speed according to his feeling.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0037": {
+      "prompt": "When a vehicle goes downhill, it may fully use the neutral gear and slide.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0038": {
+      "prompt": "When encountering disabled people obstructing the traffic, the driver should voluntarily reduce speed and yield.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0039": {
+      "prompt": "When a motorized vehicle encounters the cut in by another vehicle in a roundabout, the driver may not evade as long as he has the right of way.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0040": {
+      "prompt": "When a vehicle has increased its speed to more than 60 kilometers per hour on the ramp of an expressway, it may directly enter the carriageway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0041": {
+      "prompt": "When a vehicle leaves an expressway, it should reduce speed in the deceleration lane before entering the ramp.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0042": {
+      "prompt": "A small bus driver should reduce speed rapidly when he suddenly feel bumpy on a flat expressway, to prevent tire blowout.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0043": {
+      "prompt": "When a vehicle goes uphill on a mountain road, it should change to a lower gear in a timely, accurate and rapid manner so as to avoid a situation in which driving at a high gear can reduce the power of the engine.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0044": {
+      "prompt": "When driving at night, the driver should go at a lower speed because his field of vision is limited and he can hardly observe the traffic conditions beyond the area covered by his vehicle light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0045": {
+      "prompt": "When overtaking, the driver should try his best to increase the horizontal distance and, when necessary, may cross the solid line to overtake.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0046": {
+      "prompt": "A driver should observe the dynamic situation of the rear side vehicles before driving into the traffic flow from other road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0047": {
+      "prompt": "When a vehicles turns, it should do so on the right side and refrain from occupying the lane of the other party. The left turn should be gentle and the right turn should be sharp.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0048": {
+      "prompt": "A vehicle may stop on the ramp of an expressway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0049": {
+      "prompt": "A vehicle is not allowed to reverse on the ramp of an expressway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0050": {
+      "prompt": "When driving at night, the driver should try as much as possible to avoid overtaking. When he really needs to overtake, he may switch the high and low beam lights to alert the vehicle in front.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0051": {
+      "prompt": "When following a vehicle, the following vehicle may use the high beam light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0052": {
+      "prompt": "As the braking distance increases on a wet road in a rainy day, the driver should use the emergency brake as much as possible to reduce speed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0053": {
+      "prompt": "When the driver senses a tire blowout on the road, he should control the direction of the vehicle, gently depress the brake pedal to slowly reduce the speed and gradually park the vehicle steadily on the roadside.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0054": {
+      "prompt": "When driving a vehicle on the road, the driver should drive safely at the prescribed speed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0055": {
+      "prompt": "When a vehicle merges with the traffic flow, the driver should turn on the turn signal in advance, go straight, observe the traffic conditions on both sides through the rear-view mirror, and merge with the traffic flow if it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0056": {
+      "prompt": "When a vehicle passes a crosswalk, the driver should yield to the pedestrians.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0057": {
+      "prompt": "Before a vehicle enters an intersection, the driver should reduce speed, observe and make sure it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0058": {
+      "prompt": "After the green light at an intersection is on, the vehicles may not yield if non-motorized vehicles cut in.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0059": {
+      "prompt": "When reaching a sharp curve, the driver should reduce speed and drive on the right side so as to avoid colliding with the vehicle crossing the central line of the curve in the opposite direction.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0060": {
+      "prompt": "According to rules on the road traffic safety, the maximum speed on the expressway is less than 120km/hr, thus, it will not be in violation of the traffic regulations as long as the speed does not exceed 120km/hr on the expressway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0061": {
+      "prompt": "When a motorized vehicle goes at night through an intersection that has no traffic lights, the driver should not use the high and low beam lights alternately.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0062": {
+      "prompt": "A rear tire blowout can sway the tail of the vehicle. The driver should firmly hold the steering wheel with both hands to ensure the vehicle go straight, reduce speed and then stop.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0063": {
+      "prompt": "When driving at night, the drivers visibility range becomes shorter and his observation becomes poorer. At the same time, the driver can easily become tired because he has to highly concentrate his attention.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0064": {
+      "prompt": "When driving in icy and snowy weather, the vehicle steadiness decreases and sudden acceleration can very easily cause spins and slides.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0065": {
+      "prompt": "It is a bad habit for a driver to put his left arm on the window of the vehicle or hold the gear lever in his right hand for a long time.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0066": {
+      "prompt": "When a vehicle starts up, the driver should observe the traffic conditions and begin to start up after making sure it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0067": {
+      "prompt": "When a vehicle passes a sharp curve, it may overtake if traffic is light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0068": {
+      "prompt": "After a vehicle enters the ramp, the driver should swiftly increase the speed to more than 60 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0069": {
+      "prompt": "When changing lanes on an expressway, the driver should turn on the turn signal in advance, observe the traffic conditions, and slowly turn the steering wheel and enter the new lane after making sure it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0070": {
+      "prompt": "When a vehicle goes uphill, the driver should observe the road conditions and the length of the slope in advance and shift to the lower gear in a timely manner to ensure the vehicle has sufficient power.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0071": {
+      "prompt": "Honking in a foggy day can arouse the attention of the opposite side. After hearing the honking from the opposite side, the driver should also honk to respond.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0072": {
+      "prompt": "When following a vehicle on the road, the distance from the vehicle in front is not important. As long as the driver goes forward at the same speed as the vehicle in front does, he can avoid rear-end collision.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0073": {
+      "prompt": "If the driver finds there is no vehicle following, he can change lanes without turning on the turn signal.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0074": {
+      "prompt": "When a vehicle passes a narrow road or bridge, it is prohibited from overtaking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0075": {
+      "prompt": "In the course of making a U turn, the driver should strictly control the speed, carefully observe the road conditions before and behind the vehicle, and may advance or reverse only if it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0076": {
+      "prompt": "When reaching an intersection, a left-turning vehicle may enter the left-turn waiting area anytime.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0077": {
+      "prompt": "When driving in thick fog causing poor visibility on the expressway, the driver should apply emergency braking to stop at once.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0078": {
+      "prompt": "When a vehicle goes downhill, the driver should properly control the speed and fully use the engine to brake.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0079": {
+      "prompt": "When a vehicle starts to move at night, the driver should first turn on the low beam light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0080": {
+      "prompt": "When driving at night on a road with no or poor lighting, the driver should switch from the low beam light to the high beam light. But the vehicle following in the same direction is not allowed to use the high beam light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0081": {
+      "prompt": "When driving in windy, rainy, snowy, foggy and other complex weather conditions, the driver should turn on the head light, honk continuously and overtake rapidly if the vehicle in front goes slowly.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0082": {
+      "prompt": "When there is a continuous rain, the shoulders of the mountain roads may become loose and the embankments may collapse. When driving in this weather, the driver should select the middle solid road and refrain from going close to the roadsides.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0083": {
+      "prompt": "When the vehicle has changed its direction due to a front tire blowout on the road, the driver should firmly hold the steering wheel with both hands to ensure the vehicle goes straight.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0084": {
+      "prompt": "Driving and smoking has no harm on safe driving.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0085": {
+      "prompt": "When encountering a traffic jam on the expressway, the driver should follow the front vehicle lining up, and immediately turn on the hazard light to prevent rear-end collision.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0086": {
+      "prompt": "When a vehicle goes downhill on a mountain road, it is not allowed to overtake.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0087": {
+      "prompt": "When a vehicle reaches a muddy or burst-and-muddy section, the driver should stop, observe and select the level and solid section or the section with vehicle tracks.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0088": {
+      "prompt": "When a tire blows out suddenly on the road, the driver should refrain from violently depressing the brake pedal in panic. Instead, he should try his best to shift the gear to a low position and use the engine braking to reduce the speed of the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0089": {
+      "prompt": "It is not safe for a woman driver to wear high heels to drive a vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0090": {
+      "prompt": "When the driver senses a tire blowout on the road, he should control the direction of the vehicle and use emergency braking to bring the vehicle swiftly to a stop.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0091": {
+      "prompt": "It is illegal for a driver to use a cell phone while driving.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0092": {
+      "prompt": "When the traffic conditions at an intersection are complicated, the driver should be patiently waiting instead of taking chance.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0093": {
+      "prompt": "When a vehicle passes a curve on a mountain road, the driver should reduce speed, honk and stick to the right.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0094": {
+      "prompt": "As thick fog reduces visibility, turning on the high beam light can increase the visibility.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0095": {
+      "prompt": "When driving on a road covered by ice and snow, the driver must reduce speed and increase the safe distance.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0096": {
+      "prompt": "A qualified driver should not only be technically adept, but more importantly have good driving habits and ethical attainments.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0097": {
+      "prompt": "When a vehicle changes lane, the driver only needs to turn on the turn signal before rapidly entering the new lane.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0098": {
+      "prompt": "A vehicle should try to speed up after starting from the roadside and rapidly turn left into the traffic flow on the road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0099": {
+      "prompt": "When the driver discovers a tire is leaking and steers the vehicle off the main carriageway, he should refrain from applying emergency so as to avoid a vehicle turnover or a rear-end collision arising from the late braking of the following vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0100": {
+      "prompt": "A front tire blowout is very dangerous. The vehicle will immediately turn to the side where the tire is blown out and have a direct impact on the drivers control of the steering wheel.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0101": {
+      "prompt": "When driving at night, the drivers observation ability is visibly poorer and his visibility range becomes shorter than driving in the daytime.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0102": {
+      "prompt": "Emergency braking on a road covered by ice and snow can easily cause side skidding. The driver should use the engine braking to reduce speed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0103": {
+      "prompt": "The vehicles should run by the right shoulder of an expressway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0104": {
+      "prompt": "When a vehicle changes to the right lane, the driver should turn on the right-turn signal in advance, observe and enter the new lane if it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0105": {
+      "prompt": "When encountering non-motorized vehicles cutting in on the road, the driver should ___.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0105_o1": "Honk to warn",
+        "q0105_o2": "Speed up and pass",
+        "q0105_o3": "Reduce speed and yield",
+        "q0105_o4": "Suddenly speed up when approaching"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0106": {
+      "prompt": "When a vehicle has to stop on an expressway due to a vehicle trouble, the driver should place a breakdown warning sign beyond ______ meters behind the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0106_o1": "25",
+        "q0106_o2": "150",
+        "q0106_o3": "100",
+        "q0106_o4": "50"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0107": {
+      "prompt": "When driving a vehicle through an inundated road with non-motorized vehicles on both sides, the driver should _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0107_o1": "Reduce speed and go slowly",
+        "q0107_o2": "Go forward normally",
+        "q0107_o3": "Speed up and pass",
+        "q0107_o4": "Continuously honk"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0108": {
+      "prompt": "When the green arrow for a lane is on and there are still pedestrians in the crosswalk before the vehicle, the driver should ___________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0108_o1": "Directly start up and pass",
+        "q0108_o2": "Start up and bypass the pedestrians from behind",
+        "q0108_o3": "Start up and bypass before the pedestrians",
+        "q0108_o4": "Start up after the pedestrians have passed"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0109": {
+      "prompt": "Before entering a level crossing, the vehicle should reduce speed and change to a lower gear, and _____ after entering the level crossing.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0109_o1": "Cannot change gear",
+        "q0109_o2": "Can change gear",
+        "q0109_o3": "Can change to a higher gear",
+        "q0109_o4": "Stop and look"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0110": {
+      "prompt": "As the road is wet and slippery after rain, brake application when driving can easily ___.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0110_o1": "Cause sideways slide and traffic accident",
+        "q0110_o2": "Cause collision due to poor visibility",
+        "q0110_o3": "Be ignored by the drivers of other vehicles",
+        "q0110_o4": "Cause engine kill"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0111": {
+      "prompt": "7.When a vehicle changes lane before an intersection, the driver should do so ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0111_o1": "In the area marked by solid lines before the intersection",
+        "q0111_o2": "In the area marked by solid lines in the intersection",
+        "q0111_o3": "In the area marked by broken lines as indicated by the guide arrow",
+        "q0111_o4": "Before the stop line at the intersection"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0112": {
+      "prompt": "When passing an unmanned level crossing, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0112_o1": "Speed up and pass",
+        "q0112_o2": "Reduce speed and pass",
+        "q0112_o3": "Maintain the speed and pass",
+        "q0112_o4": "Stop, look and pass"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0113": {
+      "prompt": "The main impact of foggy weather on safe driving is _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0113_o1": "The engine can easily stop",
+        "q0113_o2": "The vehicle can easily slide sideways",
+        "q0113_o3": "The resistance the vehicle increases",
+        "q0113_o4": "The visibility is low and the vision is poor"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0114": {
+      "prompt": "When a vehicle stops temporarily in a snowy day, the driver should turn on _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0114_o1": "The head and tail fog light",
+        "q0114_o2": "The reserve light",
+        "q0114_o3": "The high beam light",
+        "q0114_o4": "The hazard lights"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0115": {
+      "prompt": "Driving on the expressway with full signs and marking, the driver should run in the lane and at the speed according to _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0115_o1": "Signs and markings",
+        "q0115_o2": "Rules on road traffic safety",
+        "q0115_o3": "Vehicle manual",
+        "q0115_o4": "Local regulations"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0116": {
+      "prompt": "The main feature of pedestrians participating in road traffic is that _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0116_o1": "They move slowly",
+        "q0116_o2": "They like to get together and look on",
+        "q0116_o3": "They walk around at will and can easily change directions",
+        "q0116_o4": "All the above"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0117": {
+      "prompt": "When passing through an inundated road, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0117_o1": "Reduce speed and go slowly",
+        "q0117_o2": "Maintain the normal speed and pass",
+        "q0117_o3": "slide over in the neutral gear",
+        "q0117_o4": "Speed up and pass"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0118": {
+      "prompt": "When discovering a road congestion ahead, the correct way to deal with this situation is to _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0118_o1": "Continue to weave through",
+        "q0118_o2": "Find space and overtake one vehicle after another",
+        "q0118_o3": "Honk to indicate the vehicle in front to speed up",
+        "q0118_o4": "Stop and wait in line"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0119": {
+      "prompt": "When a driver needs to borrow a lane to bypass an obstacle in front and a vehicle in the opposite direction is approaching the obstacle, the driver should ___________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0119_o1": "Reduce speed or stop and yield to the vehicle coming in the opposite direction",
+        "q0119_o2": "Speed up and bypass the obstacle in advance",
+        "q0119_o3": "Honk to indicate the vehicle in the opposite direction to yield",
+        "q0119_o4": "Rapidly occupy the lane and force the vehicle coming in the opposite direction to stop and yield"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0120": {
+      "prompt": "When encountering non-motorized vehicles intending to bypass a stopping vehicle, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0120_o1": "Honk to indicate them to yield",
+        "q0120_o2": "Yield to them",
+        "q0120_o3": "Speed up and bypass",
+        "q0120_o4": "Follow them closely and honk"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0121": {
+      "prompt": "When running on an expressway, the driver should ____ if he has missed the exit.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0121_o1": "Reverse to the original place",
+        "q0121_o2": "Continue to go ahead and find the next exit",
+        "q0121_o3": "Immediately stop",
+        "q0121_o4": "Make a U turn from where he is"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0122": {
+      "prompt": "When a motorized vehicle runs on an expressway, it ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0122_o1": "May stop on the road shoulder to let passengers on and off",
+        "q0122_o2": "May stop in the emergency lane to load and unload cargos",
+        "q0122_o3": "May overtake or stop in the acceleration or deceleration lane",
+        "q0122_o4": "Is not allowed to drive or stop in the emergency lane in a non-emergency case"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0123": {
+      "prompt": "When encountering a vehicle coming in the opposite direction on a mountain road, the driver should ______ when crossing each other.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0123_o1": "Not reduce speed",
+        "q0123_o2": "Stick to the center of the road",
+        "q0123_o3": "Speed up",
+        "q0123_o4": "Reduce speed or stop to yield"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0124": {
+      "prompt": "Is there any effective auxiliary method to control the speed while driving on a long downhill road besides braking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0124_o1": "Shift to the neutral gear and slide",
+        "q0124_o2": "Use the engine to brake",
+        "q0124_o3": "Turn off the engine and slide",
+        "q0124_o4": "Depress the clutch and slide"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0125": {
+      "prompt": "The wrong measure to avoid tire blowout is to _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0125_o1": "Reduce tire pressure",
+        "q0125_o2": "Check the tires regularly",
+        "q0125_o3": "Remove objects from tire tread grooves in a timely manner",
+        "q0125_o4": "Replace the tire that has cracks or deep cuts"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0126": {
+      "prompt": "The main impact of the road conditions at night on safe driving is ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0126_o1": "The visibility is low and unfavorable for observing road traffic conditions",
+        "q0126_o2": "The road surface is complex and changing",
+        "q0126_o3": "The physical strength of the driver decreases",
+        "q0126_o4": "The driver can easily have impulse and illusion"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0127": {
+      "prompt": "When a vehicle coming in the opposite direction suddenly overtakes and occupies your lane, the correct way to deal with this situation is to __________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0127_o1": "Obstruct the way of that vehicle",
+        "q0127_o2": "Maintain the original speed",
+        "q0127_o3": "Reduce speed and avoid as much as possible, till stop",
+        "q0127_o4": "Speed up and go forward"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0128": {
+      "prompt": "When a vehicle approaches a crosswalk, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0128_o1": "Speed up and pass",
+        "q0128_o2": "Stop immediately",
+        "q0128_o3": "Honk to indicate the pedestrians to yield",
+        "q0128_o4": "Observe the movement of pedestrians and non-motorized vehicles, make sure it is safe before passing"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0129": {
+      "prompt": "If a vehicle enters a left lane for overtaking but is unable to ensure a safe horizontal distance with the normally-running vehicle in front, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0129_o1": "Speed up and overtake",
+        "q0129_o2": "Overtake after running a distance in parallel",
+        "q0129_o3": "Give up overtaking",
+        "q0129_o4": "Overtake with care"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0130": {
+      "prompt": "Before a vehicle enters a curve of a mountain road, the driver ______ if there is no vehicle coming in the opposite direction.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0130_o1": "Should reduce speed, honk and drive on the right side",
+        "q0130_o2": "Should drive along the outer side of the curve",
+        "q0130_o3": "May briefly borrow the opposite lane",
+        "q0130_o4": "May speed up and pass along the tangent line of the curve"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0131": {
+      "prompt": "When reaching an intersection, the driver should _____ if a turning vehicle cuts in.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0131_o1": "Stop to evade",
+        "q0131_o2": "Maintain the normal speed",
+        "q0131_o3": "Speed up and pass ahead of it",
+        "q0131_o4": "Honk and pass ahead of it"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0132": {
+      "prompt": "Continuously using the foot brake on a long downhill road ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0132_o1": "Can shorten the engines service life",
+        "q0132_o2": "Increases the drivers labor intensity",
+        "q0132_o3": "Can drastically reduce the braking efficiency due to the rising temperature of the brake",
+        "q0132_o4": "Can easily cause vehicle overturn"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0133": {
+      "prompt": "When a vehicle enters a two-way tunnel, the driver should turn on ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0133_o1": "The hazard lights",
+        "q0133_o2": "The high beam light",
+        "q0133_o3": "The fog light",
+        "q0133_o4": "The width light or the low beam light"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0134": {
+      "prompt": "When driving at night on a road that has good lighting, the driver should use _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0134_o1": "The fog light",
+        "q0134_o2": "The low beam light",
+        "q0134_o3": "The high beam light",
+        "q0134_o4": "The hazard lights"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0135": {
+      "prompt": "When finding a vehicle in the opposite direction having difficulty to go forward and needing to borrow road while crossing each other, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0135_o1": "Not occupy the road of the other side and should go forward normally",
+        "q0135_o2": "Indicate the other side to stop and yield",
+        "q0135_o3": "Speed up and go forward by the right side",
+        "q0135_o4": "Yield to the other side as much as possible"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0136": {
+      "prompt": "When a following vehicle gives the overtaking signal, the driver should ________ if conditions permit.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0136_o1": "Move to the right side and speed up",
+        "q0136_o2": "Voluntarily reduce speed and drive along the right side",
+        "q0136_o3": "Yield a proper space and speed up",
+        "q0136_o4": "Reduce speed rapidly or apply an emergency braking"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0137": {
+      "prompt": "When a vehicle approaches an intersection without crosswalk, the driver should _______ if he finds people are crossing the street.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0137_o1": "Reduce speed or stop to yield",
+        "q0137_o2": "Honk to indicate them to yield",
+        "q0137_o3": "Immediately change lane and bypass the pedestrians",
+        "q0137_o4": "Pass before the pedestrians"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0138": {
+      "prompt": "When encountering an ambulance rushing in the same lane in the opposite direction, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0138_o1": "Move to the road side, reduce speed or stop to yield",
+        "q0138_o2": "Drive on by using another lane",
+        "q0138_o3": "Speed up and change lane to avoid",
+        "q0138_o4": "Continue to go in the original lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0139": {
+      "prompt": "When a vehicle encounters a bike rider coming in the opposite direction on the road, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0139_o1": "Continuously change the high and low bean lights",
+        "q0139_o2": "Continuously honk",
+        "q0139_o3": "Use the low beam light, reduce speed or stop to evade",
+        "q0139_o4": "Use the high beam light"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0140": {
+      "prompt": "When a vehicle on the main road approaches a conjunction with a feeder road, the driver should ______ in order to prevent a collision with a vehicle that suddenly enters from the feeder road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0140_o1": "Maintain the normal speed",
+        "q0140_o2": "Reduce speed in advance, observe and drive with care",
+        "q0140_o3": "Honk and swiftly pass",
+        "q0140_o4": "Speed up in advance and pass"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0141": {
+      "prompt": "When a vehicle approaches a bus stopping at a bus stop, the driver should ______ in case the bus starts up suddenly or pedestrians cross in front of the bus.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0141_o1": "Reduce speed, keep a sufficient distance and be ready to stop anytime",
+        "q0141_o2": "Maintain the normal speed",
+        "q0141_o3": "Honk to remind, speed up and pass",
+        "q0141_o4": "Be ready to apply emergency braking"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0142": {
+      "prompt": "After entering the acceleration lane of an expressway, the driver should increase the speed to more than _________ kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0142_o1": "50",
+        "q0142_o2": "60",
+        "q0142_o3": "30",
+        "q0142_o4": "40"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0143": {
+      "prompt": "When running on an expressway that has four lanes in the same direction, the vehicles whose speed is higher than 110 kilometers per hour should run ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0143_o1": "The far left lane",
+        "q0143_o2": "The second left lane",
+        "q0143_o3": "The far right lane",
+        "q0143_o4": "The third left lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0144": {
+      "prompt": "When a vehicle runs on a narrow mountain road, the driver should ______ if the party close to the mountain mass refuses to yield.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0144_o1": "Honk to urge the other party to yield",
+        "q0144_o2": "Maintain the normal speed",
+        "q0144_o3": "Reduce speed or stop to yield",
+        "q0144_o4": "Use the left lane and pass with care"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0145": {
+      "prompt": "When driving in a rainstorm and the windscreen wiper cannot totally wipe off the rain water, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0145_o1": "Concentrate his attention and drive with care",
+        "q0145_o2": "Immediately reduce speed and stop at the road side",
+        "q0145_o3": "Maintain the normal speed",
+        "q0145_o4": "Drive at a reduced speed"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0146": {
+      "prompt": "The reason that a road destroyed by flood affects safe driving and smooth passage is __.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0146_o1": "The road grip becomes stronger",
+        "q0146_o2": "It is impossible to see the hidden holes and bumps in road surface",
+        "q0146_o3": "The visibility become lower and blurs the field of vision",
+        "q0146_o4": "The sunshine reflection blurs the view"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0147": {
+      "prompt": "When encountering a traffic accident ahead and help is needed while driving, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0147_o1": "Bypass to dodge it as much as possible",
+        "q0147_o2": "Immediately report to the police, stop and look on.",
+        "q0147_o3": "Help to preserve the scene and immediately report to the police",
+        "q0147_o4": "Speed up and pass to ignore it"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0148": {
+      "prompt": "When overtaking a vehicle stopping on the right side, the driver should ________ in case that vehicle starts up suddenly or opens the door.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0148_o1": "Speed up and pass",
+        "q0148_o2": "Keep honking",
+        "q0148_o3": "Maintain the normal speed",
+        "q0148_o4": "Keep a safe horizontal distance from that vehicle, reduce speed and pass"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0149": {
+      "prompt": "When entering an expressway toll gate, the driver should select a gate where _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0149_o1": "There are more vehicles",
+        "q0149_o2": "The red light is on",
+        "q0149_o3": "The green light is on",
+        "q0149_o4": "Service is temporarily suspended"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0150": {
+      "prompt": "When driving in a foggy day, the driver should turn on ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0150_o1": "The reverse light",
+        "q0150_o2": "The low beam light",
+        "q0150_o3": "The fog light",
+        "q0150_o4": "The high beam light"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0151": {
+      "prompt": "When a vehicle wades across the water, the driver should maintain a low speed, and _____ the brake pedal so as to restore the braking efficiency.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0151_o1": "Continuously and strongly depress",
+        "q0151_o2": "Intermittently and strongly depress",
+        "q0151_o3": "Continuously and gently depress",
+        "q0151_o4": "Intermittently and gently depress"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0152": {
+      "prompt": "When driving in icy and snowy weather, ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0152_o1": "The braking distance becomes longer",
+        "q0152_o2": "The resistance to slide becomes larger",
+        "q0152_o3": "The braking performance does not change",
+        "q0152_o4": "The road grip becomes stronger"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0153": {
+      "prompt": "When driving a vehicle through an inundated road with pedestrians on both sides, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0153_o1": "Speed up and pass",
+        "q0153_o2": "Go forward normally",
+        "q0153_o3": "Continuously honk",
+        "q0153_o4": "Reduce speed and go slowly"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0154": {
+      "prompt": "When starting up a vehicle stopping at the roadside, the driver should first ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0154_o1": "Depress the accelerator pedal and start",
+        "q0154_o2": "Honk",
+        "q0154_o3": "Increase engine rotation speed",
+        "q0154_o4": "Observe the conditions around the vehicles"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0155": {
+      "prompt": "When the green light at a congested intersection is on, the vehicles _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0155_o1": "May directly enter the intersection",
+        "q0155_o2": "Cannot enter the intersection",
+        "q0155_o3": "May pass the intersection by borrowing the opposite lane",
+        "q0155_o4": "Enter the intersection if it is safe to do so"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0156": {
+      "prompt": "When a vehicle passes a bumped road, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0156_o1": "Speed up and dash over under inertia",
+        "q0156_o2": "Change to the neutral gear and slide over",
+        "q0156_o3": "Maintain the original speed and pass",
+        "q0156_o4": "Pass slowly and steadily"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0157": {
+      "prompt": "When a vehicle overtakes the bike riders going in the same direction, the rational way to deal with is to ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0157_o1": "Continuously honk to remind them to yield",
+        "q0157_o2": "Continuously honk and speed up to overtake",
+        "q0157_o3": "Yield to the bike riders",
+        "q0157_o4": "Observe them, reduce speed and go slowly, while keeping a sufficient safe distance."
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0158": {
+      "prompt": "When a motorized vehicle stops temporarily at the roadside, the driver ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0158_o1": "Is not allowed to stop in the opposite direction or in parallel",
+        "q0158_o2": "May stop anyway he likes as long as it is convenient for him to get out",
+        "q0158_o3": "May stop the vehicle in the opposite direction",
+        "q0158_o4": "May stop the vehicle in parallel"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0159": {
+      "prompt": "When a vehicle follows another vehicle on a mountain road, it should ____.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0159_o1": "Properly increase the safe distance",
+        "q0159_o2": "Closely follow the vehicle in front",
+        "q0159_o3": "Properly reduce the safe distance",
+        "q0159_o4": "Try to find a chance to overtake"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0160": {
+      "prompt": "If a front tire blowout has caused a turn in direction, the driver should not avoid excess adjustment. Instead, he should control the direction of the vehicle, ____, and slowly reduce the speed of the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0160_o1": "Apply emergency braking",
+        "q0160_o2": "Use the handbrake",
+        "q0160_o3": "Gently depress the brake pedal",
+        "q0160_o4": "Swiftly depress the brake pedal"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0161": {
+      "prompt": "At night, the drivers observation is markedly poorer than in the daytime and the range of visibility range is _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0161_o1": "Unchanged",
+        "q0161_o2": "Irregular",
+        "q0161_o3": "Longer",
+        "q0161_o4": "Shorter"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0162": {
+      "prompt": "When discovering a vehicle behind wanting to overtake while driving, the driver should _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0162_o1": "Maintain the original speed",
+        "q0162_o2": "Reduce speed, observe and run by the right side to yield",
+        "q0162_o3": "Speed up and go ahead by the right side",
+        "q0162_o4": "Not yield"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0163": {
+      "prompt": "When driving slowly in a congested road, the driver should ________ if another vehicle forcefully cuts in.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0163_o1": "Honk to warn it against cutting in",
+        "q0163_o2": "Speed up to closely follow the vehicle in front and refuse to allow it to cut in",
+        "q0163_o3": "Squeeze the cutting-in vehicle to force it to leave",
+        "q0163_o4": "Voluntarily yield to ensure safe driving"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0164": {
+      "prompt": "When reversing on an ordinary road and discovering some vehicles are passing, the driver should _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0164_o1": "Honk to indicate the intention",
+        "q0164_o2": "Voluntarily stop and yield",
+        "q0164_o3": "Speed up and reverse",
+        "q0164_o4": "Continue to reverse"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0165": {
+      "prompt": "When a vehicle reaches a sharp curve, the driver should _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0165_o1": "Brake suddenly and go slowly",
+        "q0165_o2": "Drive along the outer side of the curve",
+        "q0165_o3": "Fully reduce speed and drive on the right side",
+        "q0165_o4": "Go forward by borrowing the opposite lane"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0166": {
+      "prompt": "When a vehicle stops temporarily in a rainy day, the driver should turn on ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0166_o1": "The head and tail fog lights",
+        "q0166_o2": "The hazard lights",
+        "q0166_o3": "The high beam light",
+        "q0166_o4": "The reverse light"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0167": {
+      "prompt": "When driving in a rainy day, the driver should _____ when a pedestrian holding umbrella or in raincoat is walking on the highway.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0167_o1": "Continuously honk to indicate him to yield",
+        "q0167_o2": "Speed up and bypass",
+        "q0167_o3": "Honk in advance and properly reduce speed",
+        "q0167_o4": "Drive at the normal speed"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0168": {
+      "prompt": "The main impact of the road conditions in icy and snowy weather is ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0168_o1": "The electric equipment can easily get wet and cause short circuit",
+        "q0168_o2": "The visibility is lower and the field of vision is blurred",
+        "q0168_o3": "The resistance to the vehicle increases",
+        "q0168_o4": "Poor braking performance and Side pulling"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0169": {
+      "prompt": "The main impact of muddy roads on safe driving is _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0169_o1": "The resistance to the vehicle becomes weaker",
+        "q0169_o2": "The tires can easily spin and skid",
+        "q0169_o3": "The visibility become lower and blurs the field of vision",
+        "q0169_o4": "The road grip becomes stronger"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0170": {
+      "prompt": "If an improper place is chosen for crossing another vehicle, the driver should immediately _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0170_o1": "Reduce speed and cross each other slowly, or stop to yield",
+        "q0170_o2": "Occupy the left lane to force the opposite party to reduce speed and yield",
+        "q0170_o3": "Turn the head light to indicate the opposite party to stop and yield",
+        "q0170_o4": "Speed up and select a better place"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0171": {
+      "prompt": "When encountering school children crossing the road in a queue, the driver should ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0171_o1": "Speed up in advance and pass forcefully",
+        "q0171_o2": "Stop to yield",
+        "q0171_o3": "Reduce speed and go slowly",
+        "q0171_o4": "Continuously honk to urge them"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0172": {
+      "prompt": "When overtaking on a mountain road, the vehicle should overtake ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0172_o1": "By taking every possible chance",
+        "q0172_o2": "By selecting a wide gentle uphill section",
+        "q0172_o3": "By selecting a fairly long downhill section",
+        "q0172_o4": "By selecting a relatively gentle downhill section"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0173": {
+      "prompt": "When a vehicle running at night encounters a curve ahead, its lighting ____.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0173_o1": "Leave the road surface",
+        "q0173_o2": "Moves from the center of the road to the roadside",
+        "q0173_o3": "Does not change its distance",
+        "q0173_o4": "Become lower"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0174": {
+      "prompt": "When driving on a mountain road covered by ice and snow, the vehicle behind should ______ if the vehicle in front is climbing a slope.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0174_o1": "Climb slowly",
+        "q0174_o2": "Closely follow and climb",
+        "q0174_o3": "Select a proper place to stop and climb after the vehicle in front has passed",
+        "q0174_o4": "Rapidly overtake the vehicle in front"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0175": {
+      "prompt": "The main impact of rainy weather on safe driving is _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0175_o1": "The road is wet and slippery and the visibility is poor",
+        "q0175_o2": "The engine is prone to stop",
+        "q0175_o3": "The resistance to the vehicle increases",
+        "q0175_o4": "The electric equipment is prone to getting wet and causing short circuit"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0176": {
+      "prompt": "When encountering a vehicle in the opposite direction forcing its way by using his lane, the driver should _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0176_o1": "Force the other side to drive by the right side",
+        "q0176_o2": "Use the high beam light to warn the other side",
+        "q0176_o3": "Voluntarily yield to the other side",
+        "q0176_o4": "Go ahead by the center of the road"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0177": {
+      "prompt": "When a vehicle is being overtaken by another vehicle, the driver should _____.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0177_o1": "Run by the central line of the road",
+        "q0177_o2": "Speed up and yield",
+        "q0177_o3": "Continue to speed up and run",
+        "q0177_o4": "Reduce speed and run on the right side"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0178": {
+      "prompt": "When encountering children on the road, the driver should _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0178_o1": "Reduce speed and go slowly, or stop to yield when necessary",
+        "q0178_o2": "Continuously honk to urge",
+        "q0178_o3": "Swiftly bypass from one side",
+        "q0178_o4": "Speed up and bypass"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0179": {
+      "prompt": "When the tire pressure is too low, the fast-running tire can change its shape like waves and increase its temperature, which in turn can cause ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0179_o1": "Even lower tire pressure",
+        "q0179_o2": "Increases resistance to the vehicle",
+        "q0179_o3": "Tire blowout",
+        "q0179_o4": "Unstable tire pressure"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0180": {
+      "prompt": "The main impact of mountain roads on safe driving is _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0180_o1": "The traffic conditions are boring",
+        "q0180_o2": "The slopes are long, the curves are sharp and visibility range is shorter.",
+        "q0180_o3": "The traffic flow is heavy",
+        "q0180_o4": "The road signs are fewer"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0181": {
+      "prompt": "When discovering the persons injured in a traffic accident need rescue while driving, the driver should _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0181_o1": "Send the injured persons to hospital in a timely manner or make emergency calls",
+        "q0181_o2": "Dodge as much as possible",
+        "q0181_o3": "Go ahead by bypassing the scene",
+        "q0181_o4": "Find an excuse to dodge the scene"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0182": {
+      "prompt": "When discovering traffic congestion ahead while driving, the driver should ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0182_o1": "Find a chance to overtake the vehicle in front",
+        "q0182_o2": "Weave through other vehicles",
+        "q0182_o3": "Reduce speed, stop and wait in line",
+        "q0182_o4": "Honk to urge other vehicles"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0183": {
+      "prompt": "When seeing a watch for children sign while driving, the driver should _______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0183_o1": "Speed up and pass",
+        "q0183_o2": "Bypass",
+        "q0183_o3": "Maintain the normal speed",
+        "q0183_o4": "Carefully select a speed"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0184": {
+      "prompt": "When driving in thick or extremely thick fog, the driver should ____ due to low visibility.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0184_o1": "Turn on the head light and keep driving",
+        "q0184_o2": "Turn on the contour light, fog light and drive along the right side",
+        "q0184_o3": "Turn on the hazard lights and keep driving",
+        "q0184_o4": "Turn on the hazard lights, fog light, and stop at a safe place"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0185": {
+      "prompt": "When overtaking, the driver should ________ if the vehicle in front refuses to reduce speed or yield.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0185_o1": "Follow closely and find chance to overtake again",
+        "q0185_o2": "Stop overtaking",
+        "q0185_o3": "Speed up and continue to overtake",
+        "q0185_o4": "Continuously honk and speed up to overtake"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0186": {
+      "prompt": "If a vehicle has the right of way at an intersection but encounters a vehicle cutting in, the driver should _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0186_o1": "Rush to pass",
+        "q0186_o2": "Speed up in advance and pass",
+        "q0186_o3": "Reduce speed and evade, or stop to yield when necessary",
+        "q0186_o4": "Go forward at the normal speed according to the right of way and refuses to evade"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0187": {
+      "prompt": "If a motorized vehicle driver has caused a major accident in violation of the traffic regulations which has caused serious injury, the driver is subject to a prison term of less than 3 years or a criminal detention.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0188": {
+      "prompt": "Motorized vehicles should pass the intersections according to the traffic signals.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0189": {
+      "prompt": "You should speed up to go through the railway crossing in this case.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0190": {
+      "prompt": "Driving a motorized vehicle on the road should be required to be with a license plate.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0191": {
+      "prompt": "Driving a motorized vehicle in the city road which has no central line, the maximum speed can not exceed 50 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0192": {
+      "prompt": "In this case, if it has not begun going up the slope, the vehicle going uphill should yield to the one going downhill.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0193": {
+      "prompt": "This motorized vehicle parked on the roadside has no illegal act.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0194": {
+      "prompt": "You may speed up to go through the intersection in this case.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0195": {
+      "prompt": "When driving a motorized vehicle uphill, you should speed up and honk when you going to reach the top of the slope.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0196": {
+      "prompt": "If a motorized vehicle driver has caused a major traffic accident in violation of the traffic regulations which has caused human death due to his escaping, the driver is subject to a prison term of 3 years ~ 7 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0197": {
+      "prompt": "Driving a motorized vehicle on the road in violation of road traffic regulations shall be subject to relevant punishment.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0198": {
+      "prompt": "You can drive a motorized vehicle a short distance after drinking as long as it does not interfere the driving operation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0199": {
+      "prompt": "Driving a motorized vehicle on the highway which has no central line, the maximum speed can not exceed 70 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0200": {
+      "prompt": "In such road sections, you can enter the cross-hatched marking area to wait.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0201": {
+      "prompt": "When encountering an overflowing bridge, the driver should look at the situation, and passes through slowly before he makes sure that it is safe to do so.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0202": {
+      "prompt": "You can make an U turn at this intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0203": {
+      "prompt": "Traffic Police can detain the vehicle according to law if it is without the mandatory traffic accident insurance in accordance with state regulations.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0204": {
+      "prompt": "A person can not apply the motorized vehicle driving license, if he has been held for criminal liabilities according to law because of driving after drinking and causing a major traffic accident.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0205": {
+      "prompt": "If a small motor vehicle driver has assumed equal or main liability for a traffic accident causing human deaths, and his driving license has not been revoked, it shall be checked within 30 days after the end of the scoring cycle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0206": {
+      "prompt": "If the license plate of a motorized vehicle has been destroyed, the owner of the vehicle should apply for reissuing or changing to the vehicle management station at the registration place.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0207": {
+      "prompt": "A driver should drive the vehicles in accordance with the qualification listed on the driving license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0208": {
+      "prompt": "When a motorized vehicle returns to the original lane after overtaking, the driver should turn on the right-turn signal.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0209": {
+      "prompt": "Driving a motorized vehicle shall not overtake in tunnels, steep slopes and other special sections.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0210": {
+      "prompt": "When a motorized vehicle breaks down on the expressway, the persons on board should swiftly move to the right side road shoulder or emergency lane, and report to the police rapidly.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0211": {
+      "prompt": "Traffic Police can detain the vehicle according to law if it runs on the road failing to place a label of inspection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0212": {
+      "prompt": "Traffic Police can detain the accident vehicle according to law if it needs to be collected evidence of the road accident.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0213": {
+      "prompt": "Traffic Police can detain the vehicle according to law if it is suspected of using the label of inspection from other vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0214": {
+      "prompt": "When a traffic accident causing human injuries, preserve the scene and immediately report to the police.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0215": {
+      "prompt": "When the driver is suspected of drinking or drunk in a traffic accident, preserve the scene and immediately report to the police.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0216": {
+      "prompt": "A driver applies for the driving license for the first time and is during the period of probation, he can drive a motorized vehicle on expressway alone.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0217": {
+      "prompt": "Illegally assembled motorized vehicle can be drived on road as long as it is thought to be safe.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0218": {
+      "prompt": "You can not drive a motorized vehicle into the lane where the red X-shaped light or the red arrow light is on.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0219": {
+      "prompt": "May speed up to go through the crosswalk in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0220": {
+      "prompt": "You should speed up through the section with this kind of traffic marking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0221": {
+      "prompt": "A driver should buckled up before the vehicle moves.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0222": {
+      "prompt": "If the vehicle has no license plate, label of inspection or label of insurance, preserve the scene and immediately report to the police.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0223": {
+      "prompt": "One who runs away after causing a traffic accident and constitute a crime can not apply for motorized vehicle driving license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0224": {
+      "prompt": "One shall not drive a motorized vehicle during the period of deferred license checking due to military service, abroad and other reasons.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0225": {
+      "prompt": "Going though the intersection according to the traffic lights when traffic lights and command of the traffic police are inconsistency.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0226": {
+      "prompt": "Top speed in this section is 50 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0227": {
+      "prompt": "You may not use the turn signal when you change to the right lane.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0228": {
+      "prompt": "You can overtake from both sides in this case.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0229": {
+      "prompt": "You can overtake from right side in this case.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0230": {
+      "prompt": "Let the straight-going vehicle go first at this intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0231": {
+      "prompt": "Speeding up to go though the intersection before the light turns to red in this case.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0232": {
+      "prompt": "A motorized vehicle driver who escapes or commits other extremely serious acts after causing a major accident in violation of the traffic regulations is subject to a prison term of more than 7 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0233": {
+      "prompt": "If a driver has not received full penalty points, and the fine has not been paid, the penalty points will be transferred into the next scoring cycle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0234": {
+      "prompt": "The motorized vehicle driver is not allowed to drive a motorized vehicle when his driving license is detained.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0235": {
+      "prompt": "In this case, by the right side of the bus lane to overtake.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0236": {
+      "prompt": "The method and direction of changing lanes by the red car is correct.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0237": {
+      "prompt": "When running on the road having maximum speed limit signs, the motorized vehicle is not allowed to exceed the marked maximum speed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0238": {
+      "prompt": "Before a motorized vehicle overtakes, the driver should turn on the left-turn signal, use the high and low beam lights alternately or honk in advance.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0239": {
+      "prompt": "A motorized vehicle is not allowed to make a U turn at the level crossing, bridge, steep slope, tunnel or dangerous road section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0240": {
+      "prompt": "A motorized vehicle can make a U turn on this road as long as it does not interfere other vehicles.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0241": {
+      "prompt": "The passenger in the front seat does not need to buckle up when a motorized vehicle runs.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0242": {
+      "prompt": "The child in the motorized vehicle does not need to buckle up when the vehicle runs.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0243": {
+      "prompt": "When a motorized vehicle breaks down on the road and is difficult to move, the driver should place a warning sign within 50 meters behind the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0244": {
+      "prompt": "A Social vehicle is not allowed to stop in the section 30 meters to the fire hydrant or the fire brigade (station).",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0245": {
+      "prompt": "A motorized vehicle is not allowed to stop in the section 50 meters to the narrow road less than 4 meters width.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0246": {
+      "prompt": "Opening the doors of a motorized vehicle should not obstruct the flow of other vehicles and pedestrians.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0247": {
+      "prompt": "When causing a road accident involving human casualties, the driver should immediately rescue the injured people and report to the traffic police as soon as possible.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0248": {
+      "prompt": "Traffic Police can detain the vehicle according to law if it is suspected of using the label of insurance from other vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0249": {
+      "prompt": "If a motorized vehicle driver allows his vehicle to be driven by a person whose driving license has been revoked, the traffic police will detain the driving license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0250": {
+      "prompt": "When causing a road accident involving property damage, the party should leave the scene on his own but he does not leave, the traffic police can not order him to leave.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0251": {
+      "prompt": "Full penalty points of a scoring cycle because of violating the traffic regulations is 12 points.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0252": {
+      "prompt": "If a motorized vehicle driver reaches 12 penalty points during the period of probation, the probation qualification should be revoked.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0253": {
+      "prompt": "A motorized vehicle driver who has not yielded to the school bus according to stipulations is subject to a 6-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0254": {
+      "prompt": "May not turn on the turn signal when overtaking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0255": {
+      "prompt": "Can not overtake in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0256": {
+      "prompt": "You have the priviledged passing right of way in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0257": {
+      "prompt": "When passing an intersection without traffic lights, the driver should go through as fast as possible.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0258": {
+      "prompt": "A motorized vehicle is not allowed to stop in the section 50 meters to the bridge, steep slope or tunnel.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0259": {
+      "prompt": "Can leave the expressway into the ramp from this location directly.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0260": {
+      "prompt": "The act of this small passenger vehicle to enter the expressway lane is correct.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0261": {
+      "prompt": "May watch car video in good road conditions.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0262": {
+      "prompt": "May throw items to the road while driving.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0263": {
+      "prompt": "When causing a road accident involving property damage, the party should leave the scene on his own but he does not leave and causes a traffic jam, he may be subject to a fine of 200 yuan.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0264": {
+      "prompt": "Causing a traffic accident due to violating the law and regulations on road traffic safety is the rule-breaking act.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0265": {
+      "prompt": "A person who has falsified or altered the motorized vehicle driving license and if his act constitutes a crime, he should be held for criminal liabilities according to law.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0266": {
+      "prompt": "Traffic Signs and traffic markings are not traffic signals.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0267": {
+      "prompt": "When a motorized vehicle runs in a foggy weather, the driver should turn on the fog light and the hazard lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0268": {
+      "prompt": "When a motorized vehicle makes a U turn, turns around or goes down a slope, the maximum speed should not exceed 40 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0269": {
+      "prompt": "When a motorized vehicle crosses a non-motorized vehicle on a narrow road or a narrow bridge at night, the motorized vehicle should use the high beam light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0270": {
+      "prompt": "This small car can not stop here.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0271": {
+      "prompt": "When a motorized vehicle causes a minor traffic accident and obstructs traffic flow, it does not need to move.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0272": {
+      "prompt": "May stop temporarily in the lane for non-motorized vehicles in this section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0273": {
+      "prompt": "After causing a road accident, the vehicle driver needs to change the scene for rescuing the wounded, the driver should mark the location.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0274": {
+      "prompt": "If a motorized vehicle driver has caused a major accident in violation of the traffic regulations which has caused heavy loss to public or private property, the driver is subject to a prison term of less than 3 years or a criminal detention.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0275": {
+      "prompt": "If a motorized vehicle driver chases and races while driving on road, commits serious acts, the driver is subject to a prison term of less than 3 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0276": {
+      "prompt": "A motorized vehicle runs on the road without a label of insurance, the traffic police can detain the vehicle license according to law.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0277": {
+      "prompt": "Traffic Police only imposes a fine if a vehicle is suspected of using the falsified or altered label of inspection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0278": {
+      "prompt": "If a motorized vehicle driver causes a traffic accident and runs away but his conduct does not constitute a crime, he is subject to a 12-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0279": {
+      "prompt": "A motorized vehicle driver who drives after drinking is subject to a 12-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0280": {
+      "prompt": "If a motorized vehicle runs 50% faster than the specified speed limit, the driver is subject to a 3-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0281": {
+      "prompt": "Driving this motorized vehicle on road is not an illegal act.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0282": {
+      "prompt": "A person who has taken the state-controlled psychiatric substances can drive motorized vehicle in short distance.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0283": {
+      "prompt": "Traffic markings are divided into indication, warning and prohibition.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0284": {
+      "prompt": "At this position, you may speed up to pass through the section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0285": {
+      "prompt": "Driving in a dusty weather, it does not needed to turn on the head light, the contour light and the tail light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0286": {
+      "prompt": "Using the low beam light in such circumstances.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0287": {
+      "prompt": "Using the high and low beam lights alternately while driving on the road of this kind of sharp curve.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0288": {
+      "prompt": "When a motorized vehicle passes through narrow road or bridge, the maximum speed should not exceed 30 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0289": {
+      "prompt": "You should speed up to change lane in front of the red car.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0290": {
+      "prompt": "No U turn at this section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0291": {
+      "prompt": "When a motorized vehicle breaks down at night, and is difficult to move, the driver should turn on the hazard lights, the contour lights and the tail lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0292": {
+      "prompt": "The method of this small passenger vehicle to leave the expressway lane is correct.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0293": {
+      "prompt": "Traffic Police can detain the vehicle which is suspected of using the falsified or altered license plate and vehicle license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0294": {
+      "prompt": "Traffic Police can detain the vehicle which is suspected of using other vehicles license plate and vehicle license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0295": {
+      "prompt": "If a motorized vehicle driver allows his vehicle to be driven by a person whose driving license has been detained, the traffic police will serve an oral warning.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0296": {
+      "prompt": "The motorized vehicle driver who lives outside the jurisdiction of the issuing vehicle management station may apply to the vehicle management station at the place where he is living, for license change.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0297": {
+      "prompt": "A motorized vehicle driver who reverses, drives in the opposite direction or make a U turn by crossing the central dividing strip on the expressway is subject to a 6-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0298": {
+      "prompt": "If the vehicle license of a motorized vehicle are lost, the vehicle owner should apply to the vehicle management station at the registration place for reissuing.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0299": {
+      "prompt": "A person who has not obtained driving license drives a motorized vehicle, he will be held for legal liability.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0300": {
+      "prompt": "If a person who has caused a major traffic accident and if his act constitutes a crime, he may not be held for criminal liabilities.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0301": {
+      "prompt": "Traffic lights are divided into red, green and yellow light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0302": {
+      "prompt": "Overtaking is allowed when passing a level crossing in city where no train passes.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0303": {
+      "prompt": "You have the priviledged passing right of way at the intersection in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0304": {
+      "prompt": "You have the priviledged passing right of way at the intersection in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0305": {
+      "prompt": "When the fire engine, ambulance and wrecker are executing an emergency task, other vehicles should yield.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0306": {
+      "prompt": "Stopping temporarily on the road should not obstruct the passing of other vehicles and pedestrians.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0307": {
+      "prompt": "A motorized vehicle is not allowed to stop in the section 50 meters to the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0308": {
+      "prompt": "You can drive directly into the expressway from this position.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0309": {
+      "prompt": "If a motorized vehicle causes a traffic accident on the expressway and cannot to run normally, the vehicle should be towed by a rescue vehicle or a tow truck.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0310": {
+      "prompt": "If a motorized vehicle causes a traffic accident on the road, the driver should immediately move the vehicle to the roadside.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0311": {
+      "prompt": "Do not hang or place articles close to the front and rear windows that block the vision of the driver.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0312": {
+      "prompt": "The driving license of a motorized vehicle driver will be detained after his penalty scores reach 12 points in a scoring circle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0313": {
+      "prompt": "When causing a road accident involving property damage, the parties to the accident have no dispute over the fact and cause, they should take photos of the scene or mark the vehicles location when they move the vehicles.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0314": {
+      "prompt": "When a driver drives a motorized vehicle during the period of probation, the driver should paste or hang a uniform probation mark on the rear part of the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0315": {
+      "prompt": "A motorized vehicle driver who illegally occupies the emergency lane on the expressway is subject to a 6-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0316": {
+      "prompt": "A motorized vehicle runs on the road without a label of inspection, the traffic police can detain the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0317": {
+      "prompt": "Turn on the left-turn signal in advance when making a U turn on the road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0318": {
+      "prompt": "Use the high and low beam lights alternately when passing the crosswalk at night.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0319": {
+      "prompt": "Cannot make a U turn in this section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0320": {
+      "prompt": "Do not start up a vehicle when the door or compartment is not properly closed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0321": {
+      "prompt": "If a motorized vehicle driver has caused a major accident in violation of the traffic regulations which has caused human death, the driver is subject to a prison term of more than 3 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0322": {
+      "prompt": "A motorized vehicle driver who uses other motorized vehicles license plate and vehicle license is subject to a 3-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0323": {
+      "prompt": "Violating the law and regulations on road traffic safety is the act of violation of the law.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0324": {
+      "prompt": "Before the motorized vehicle runs on the road, the driver should check the safety and technical performance of the vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0325": {
+      "prompt": "A driver may drive on the road a motorized vehicle overhauled which has reached the scraped standard.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0326": {
+      "prompt": "A driver may drive a motorized vehicle after the driving license has been lost within 3 months.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0327": {
+      "prompt": "If the accumulated penalty points of a motorized vehicle driver reach 12 points and the driver refuses to participate in the study course and also refuses to take tests, it should be publicly announced that his driving license should no longer be used.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0328": {
+      "prompt": "Traffic signals include Traffic lights, Traffic signs and Command of the traffic police.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0329": {
+      "prompt": "Driving a motorized vehicle on the road in this condition, the maximum speed can not exceed 50 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0330": {
+      "prompt": "Stop the vehicle and observe when reaching the level crossing in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0331": {
+      "prompt": "Driving a small passenger vehicle on the expressway, the minimum speed should not be less than 90 kilometers per hour.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0332": {
+      "prompt": "Driving a motorized vehicle on the expressway is not allowed to exceed the marked maximum speed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0333": {
+      "prompt": "When a motorized vehicle breaks down on the expressway, the driver should place a warning sign 50 meters ~ 100 meters in the coming direction.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0334": {
+      "prompt": "Must reduce the frequency of honking in this section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0335": {
+      "prompt": "Traffic Police can detain the vehicle according to law if it uses other vehicles license plate and vehicle license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0336": {
+      "prompt": "If a motorized vehicle hits a building or a public facility, the vehicle may leave the scene right away.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0337": {
+      "prompt": "When causing a road accident involving property damage, the parties to the accident may leave the scene if they have no dispute over the fact and cause.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0338": {
+      "prompt": "The age should be 18 ~ 70 years old when applying for the driving license of small vehicle or three-wheeled automobile.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0339": {
+      "prompt": "A motorized vehicle driver who uses falsified or altered driving license is subject to a 12-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0340": {
+      "prompt": "A motorized vehicle driver who drives more than 50% faster than the prescribed speed limit is subject to a 12-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0341": {
+      "prompt": "Traffic Police can detain the vehicle according to law if the driver does not carry the ID card.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0342": {
+      "prompt": "A motorized vehicle driver is not allowed during the period of probation to pull a trailer.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0343": {
+      "prompt": "Turn on the right-turn signal and return immediately to the original lane after overtaking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0344": {
+      "prompt": "When encountering slow-moving vehicles at an intersection that has no traffic signals, the motorized vehicle should pass alternately.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0345": {
+      "prompt": "Speed up when passing the overflowing road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0346": {
+      "prompt": "The driver is prohibited from opening the door and letting passengers on and off when a vehicle has not come to a full stop.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0347": {
+      "prompt": "A person who falsifies, alters driving license or uses falsified, altered driving license, and if his act constitutes a crime, he should be held for criminal liabilities according to law.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0348": {
+      "prompt": "A motorized vehicle driver who violates of traffic lights is subject to a 6-point penalty.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0349": {
+      "prompt": "If a motorized vehicle has reached the states mandatory write-off standard, its registration will not be handled.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0350": {
+      "prompt": "A person whose driving license has been destroyed cannot drive a motorized vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0351": {
+      "prompt": "When the road maintenance vehicle and the engineering vehicle are on duty, the passing vehicles should avoid with care.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0352": {
+      "prompt": "When driving a small vehicle downhill, the driver may coast down by stopping the engine.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0353": {
+      "prompt": "If a motorized vehicle driver drives on the road after getting drunk is subject to a prison term of more than 3 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0354": {
+      "prompt": "Nobody is allowed to drive a motorized vehicle that has safety hazards.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0355": {
+      "prompt": "Stop and yield to the pedestrians under this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0356": {
+      "prompt": "If a person has caused a traffic accident and run away, and constitutes a crime, his driving license should be revoked and he is banned for lifetime from re-obtaining a driving license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0357": {
+      "prompt": "A person who has the expired driving license can drive motorized vehicle within 1 year.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0358": {
+      "prompt": "A driver can park the vehicle by borrowing the sidewalk if he cannot find the parking area.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0359": {
+      "prompt": "Traffic Police can detain the driver according to law, if the driver drives a motorized vehicle which is suspected of reaching the write-off standard.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0360": {
+      "prompt": "Reducing the speed when driving in sand, hail, rain, fog, ice and other weather conditions.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0361": {
+      "prompt": "Reducing the speed to yield when encountering this situation in the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0362": {
+      "prompt": "How long is the period of probation of a motor vehicle driver who has applied for a driver license for the first time?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0362_o1": "18 months",
+        "q0362_o2": "16 months",
+        "q0362_o3": "12 months",
+        "q0362_o4": "6 months"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0363": {
+      "prompt": "If a driving license is obtained by deception, bribery or other illegal means, the driving license should be revoked and the applicant is not allowed to re-apply for it _____ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0363_o1": "within 3 years",
+        "q0363_o2": "the whole life",
+        "q0363_o3": "within 1 year",
+        "q0363_o4": "within 5 years"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0364": {
+      "prompt": "How to pass this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0364_o1": "keep the speed and go through",
+        "q0364_o2": "honk to urge",
+        "q0364_o3": "reduce speed and go through slowly",
+        "q0364_o4": "speed up and go through"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0365": {
+      "prompt": "Which is correct in this kind of intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0365_o1": "make a U turn along the left lane",
+        "q0365_o2": "cannot make a U turn",
+        "q0365_o3": "make a U turn through the middle lane",
+        "q0365_o4": "make a U turn inside the intersection"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0366": {
+      "prompt": "What kind of behavior of this driver violates the law?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0366_o1": "not hold the steering wheel according to regulation",
+        "q0366_o2": "angle of the seat is not correct",
+        "q0366_o3": "not buckled up",
+        "q0366_o4": "the driving posture is incorrect"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0367": {
+      "prompt": "What is the max speed limit on this road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0367_o1": "100 km/hr",
+        "q0367_o2": "90 km/hr",
+        "q0367_o3": "120 km/hr",
+        "q0367_o4": "110 km/hr"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0368": {
+      "prompt": "How far should be the distance from the vehicle in front at the speed of more than 100 km/hr when driving a small passenger vehicle on the expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0368_o1": "more than 50 meters",
+        "q0368_o2": "more than 60 meters",
+        "q0368_o3": "more than 100 meters",
+        "q0368_o4": "more than 80 meters"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0369": {
+      "prompt": "The police can detain the vehicle if one drives a vehicle without ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0369_o1": "vehicle license",
+        "q0369_o2": "qualification certificate",
+        "q0369_o3": "ID card",
+        "q0369_o4": "pass paper"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0370": {
+      "prompt": "Which illegal conduct is subject to a 12-point penalty",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0370_o1": "violate traffic lights",
+        "q0370_o2": "use falsified license plate",
+        "q0370_o3": "call or answer the mobile phone",
+        "q0370_o4": "violate prohibitive signs"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0371": {
+      "prompt": "A motorized vehicle driver who deliberately covered or stained the license plate and placed the license plate unproperly, is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0371_o1": "2-point penalty",
+        "q0371_o2": "3-point penalty",
+        "q0371_o3": "6-point penalty",
+        "q0371_o4": "12-point penalty"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0372": {
+      "prompt": "This traffic light means ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0372_o1": "intersection warning",
+        "q0372_o2": "no passing",
+        "q0372_o3": "draw attention",
+        "q0372_o4": "allow to pass"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0373": {
+      "prompt": "How to drive in this section?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0373_o1": "occupy the road of the other side to pass the curve",
+        "q0373_o2": "drive along the middle of the curve",
+        "q0373_o3": "speed up and honk to pass",
+        "q0373_o4": "reduce speed and honk"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0374": {
+      "prompt": "Max speed when pass the narrow road or bridge is _______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0374_o1": "50km/hr",
+        "q0374_o2": "40km/hr",
+        "q0374_o3": "30km/hr",
+        "q0374_o4": "60km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0375": {
+      "prompt": "What is the max speed on the expressway when the visibility is lower than 200 meters?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0375_o1": "less than 100km/hr",
+        "q0375_o2": "less than 90km/hr",
+        "q0375_o3": "less than 60km/hr",
+        "q0375_o4": "less than 80km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0376": {
+      "prompt": "Which is subject to a 6-point penalty?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0376_o1": "violate the traffic lights",
+        "q0376_o2": "drive school bus without qualification",
+        "q0376_o3": "drive the vehicle which permission is different",
+        "q0376_o4": "drive after drink"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0377": {
+      "prompt": "Registration alternation is not needed when _____",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0377_o1": "change engine",
+        "q0377_o2": "add anti-collision device",
+        "q0377_o3": "change vehicles colour",
+        "q0377_o4": "change the chassis"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0378": {
+      "prompt": "How the front vehicle to run in this situation?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0378_o1": "run as normal",
+        "q0378_o2": "yield",
+        "q0378_o3": "turn on the hazard lights",
+        "q0378_o4": "should not change lane"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0379": {
+      "prompt": "Which should be carried onboard?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0379_o1": "insurance policy",
+        "q0379_o2": "vehicle license",
+        "q0379_o3": "certificate of ex-factory inspection",
+        "q0379_o4": "vehicle registration papers"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0380": {
+      "prompt": "The traffic lights allow the vehicle to ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0380_o1": "turn right",
+        "q0380_o2": "stop and wait",
+        "q0380_o3": "turn left",
+        "q0380_o4": "go straight"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0381": {
+      "prompt": "Which is correct if a vehicle breaks down and is difficult to move?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0381_o1": "turn on the hazard lights",
+        "q0381_o2": "turn on all the lights of the vehicle",
+        "q0381_o3": "forbid the passengers to get off",
+        "q0381_o4": "place a warning sign in front of the vehicle"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0382": {
+      "prompt": "What is the max speed when passing a level crossing?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0382_o1": "15km/hr",
+        "q0382_o2": "20km/hr",
+        "q0382_o3": "30km/hr",
+        "q0382_o4": "40km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0383": {
+      "prompt": "How often should a driver who is more than 60 years old present the certificate of physical conditions?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0383_o1": "every 3 years",
+        "q0383_o2": "every 2 years",
+        "q0383_o3": "every 6 months",
+        "q0383_o4": "every 1 year"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0384": {
+      "prompt": "In which situation should a small car driver need check?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0384_o1": "the end of a scoring cycle",
+        "q0384_o2": "change driving license due to expiration",
+        "q0384_o3": "fail to reach 12 points in one scoring cycle",
+        "q0384_o4": "reach 12 points in one scoring cycle"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0385": {
+      "prompt": "What is the max speed when down slope, turning around and U turn?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0385_o1": "50km/hr",
+        "q0385_o2": "60km/hr",
+        "q0385_o3": "30km/hr",
+        "q0385_o4": "40km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0386": {
+      "prompt": "Which of the following vehicle in front in the same lane is not allowed to be overtaken?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0386_o1": "police car on duty",
+        "q0386_o2": "large bus or large truck",
+        "q0386_o3": "taxis",
+        "q0386_o4": "public bus"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0387": {
+      "prompt": "Which is correct when changing lane?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0387_o1": "turn on the directional signal and turn left quickly",
+        "q0387_o2": "reduce speed properly when entering the left lane",
+        "q0387_o3": "cannot interfere other vehicles",
+        "q0387_o4": "speed up to enter the left lane"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0388": {
+      "prompt": "What is the max speed at sharp curve?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0388_o1": "20km/hr",
+        "q0388_o2": "30km/hr",
+        "q0388_o3": "40km/hr",
+        "q0388_o4": "50km/hr"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0389": {
+      "prompt": "Which is incorrect when a motorized vehicle breaks down on the expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0389_o1": "place warning sign as required",
+        "q0389_o2": "passengers cannot get off",
+        "q0389_o3": "call the police at once",
+        "q0389_o4": "turn on the hazard lights"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0390": {
+      "prompt": "Driving license will be detained if you allow to drive your car.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0390_o1": "driver during the period of probation",
+        "q0390_o2": "driver who has obtained a driving license",
+        "q0390_o3": "one whose driving license been revoked",
+        "q0390_o4": "one whose penalty points reach 6 points"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0391": {
+      "prompt": "How to use lights when entering the speed-reducing lane?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0391_o1": "turn on the hazard lights",
+        "q0391_o2": "turn on the head light",
+        "q0391_o3": "turn on the left-turn signal",
+        "q0391_o4": "turn on the right-turn signal"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0392": {
+      "prompt": "How to do when causing a minor traffic accident with no human casualties and no dispute?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0392_o1": "do not move the vehicle",
+        "q0392_o2": "counsel other vehicles bypass",
+        "q0392_o3": "leave the scene and discuss on their own",
+        "q0392_o4": "protect the scene and discuss"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0393": {
+      "prompt": "In which situation the traffic police may detain the vehicle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0393_o1": "no lable of inspection",
+        "q0393_o2": "no ID card",
+        "q0393_o3": "no lable of environmental protection",
+        "q0393_o4": "no vehicle registration papers"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0394": {
+      "prompt": "The penalty points will be _____ if violating the traffic lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0394_o1": "2-point penalty",
+        "q0394_o2": "3-point penalty",
+        "q0394_o3": "6-point penalty",
+        "q0394_o4": "12-point penalty"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0395": {
+      "prompt": "Which is correct when learning driving on road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0395_o1": "drive the corresponding coach car with coach sitting by to guide",
+        "q0395_o2": "drive the corresponding coach car alone",
+        "q0395_o3": "drive the corresponding coach car with other one who is not a coach sitting by to guide",
+        "q0395_o4": "drive the private car with coach sitting by to guide"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0396": {
+      "prompt": "What is the max speed on muddy road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0396_o1": "15km/hr",
+        "q0396_o2": "20km/hr",
+        "q0396_o3": "40km/hr",
+        "q0396_o4": "30km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0397": {
+      "prompt": "How to do while entering this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0397_o1": "shift the high and low beam lights alternately to remind the cars already in the intersection to yield",
+        "q0397_o2": "quickly cut in the cars already in the intersection",
+        "q0397_o3": "let the cars already in the intersection go first",
+        "q0397_o4": "honk and enter directly"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0398": {
+      "prompt": "How to run through this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0398_o1": "honk to let it yield",
+        "q0398_o2": "directly speed up to make a turn",
+        "q0398_o3": "reduce speed and turn slowly",
+        "q0398_o4": "yield the car coming from left"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0399": {
+      "prompt": "What is the max speed on this expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0399_o1": "60km/hr",
+        "q0399_o2": "90km/hr",
+        "q0399_o3": "90km/hr",
+        "q0399_o4": "120km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0400": {
+      "prompt": "What is the max speed when passing this curve?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0400_o1": "40km/hr",
+        "q0400_o2": "30km/hr",
+        "q0400_o3": "50km/hr",
+        "q0400_o4": "70km/hr"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0401": {
+      "prompt": "What is the max speed when visibility is less than 50m due to foggy, rainy or snowy?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0401_o1": "70km/hr",
+        "q0401_o2": "50km/hr",
+        "q0401_o3": "40km/hr",
+        "q0401_o4": "30km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0402": {
+      "prompt": "How to make a U turn in this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0402_o1": "broken lines of the central line",
+        "q0402_o2": "make a U turn from the right lane",
+        "q0402_o3": "enter the intersection and make a U turn",
+        "q0402_o4": "make a U turn in the crosswalk"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0403": {
+      "prompt": "How long can a driver drives without rest?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0403_o1": "less than 6hrs",
+        "q0403_o2": "less than 8hrs",
+        "q0403_o3": "less than 10hrs",
+        "q0403_o4": "less than 4hrs"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0404": {
+      "prompt": "What will be subject to if driving the vehicle reached write-off standard?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0404_o1": "a 20~200 yuan fine",
+        "q0404_o2": "being held for criminal liabilities",
+        "q0404_o3": "being detained for less than 15 days",
+        "q0404_o4": "being revoked the driving license"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0405": {
+      "prompt": "Fine will be 200~2000 yuan and driving license will be revoked if _____",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0405_o1": "violating traffic regulations",
+        "q0405_o2": "running 50% faster than the specified speed limit",
+        "q0405_o3": "escaped after causing traffic accident",
+        "q0405_o4": "driving without driver license"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0406": {
+      "prompt": "Which of the following vehicle in front in the same lane is not allowed to be overtaken?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0406_o1": "the vehicle is making a stop",
+        "q0406_o2": "the vehicle is reducing speed to yield",
+        "q0406_o3": "the vehicle is taking a U turn",
+        "q0406_o4": "the vehicle is running normally"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0407": {
+      "prompt": "On which kind of city road a vehicle is not allowed to overtake?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0407_o1": "main streets",
+        "q0407_o2": "one-way section",
+        "q0407_o3": "section with heavy traffic flow",
+        "q0407_o4": "two one-way lanes"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0408": {
+      "prompt": "Which lane to choose when turning left in this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0408_o1": "the far left lane",
+        "q0408_o2": "middle lane",
+        "q0408_o3": "not need to change lane",
+        "q0408_o4": "the far right lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0409": {
+      "prompt": "What is the Minimum speed on this expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0409_o1": "100km/hr",
+        "q0409_o2": "80km/hr",
+        "q0409_o3": "60km/hr",
+        "q0409_o4": "50km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0410": {
+      "prompt": "What is the Minimum speed in this lane?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0410_o1": "100km/hr",
+        "q0410_o2": "110km/hr",
+        "q0410_o3": "60km/hr",
+        "q0410_o4": "90km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0411": {
+      "prompt": "What is the max speed on the expressway when the visibility is lower than 100 meters?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0411_o1": "less than 40km/hr",
+        "q0411_o2": "less than 60km/hr",
+        "q0411_o3": "less than 80km/hr",
+        "q0411_o4": "less than 90km/hr"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0412": {
+      "prompt": "What to do besides controlling speed less than 20km/hr when the visibility is lower than 50 meters on the expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0412_o1": "run in the emergency lane",
+        "q0412_o2": "leave the expressway as soon as possible",
+        "q0412_o3": "stop by the roadside as soon as possible",
+        "q0412_o4": "run slowly in the road shoulder"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0413": {
+      "prompt": "What will be subject to if submitting false materials to apply for driving license?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0413_o1": "a 20~200 yuan fine",
+        "q0413_o2": "disqualification for applying for",
+        "q0413_o3": "cannot re-apply for within 1 year",
+        "q0413_o4": "cannot re-apply for within 2 years"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0414": {
+      "prompt": "What does the traffic light mean?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0414_o1": "allowed to pass",
+        "q0414_o2": "draw attention",
+        "q0414_o3": "intersection warning",
+        "q0414_o4": "prohibited from passing"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0415": {
+      "prompt": "How to run on this road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0415_o1": "run in the middle of the road",
+        "q0415_o2": "run on both side of the road",
+        "q0415_o3": "run according to lanes",
+        "q0415_o4": "go forward at will"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0416": {
+      "prompt": "What kind of lane that the red car running in?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0416_o1": "fast lane",
+        "q0416_o2": "slow lane",
+        "q0416_o3": "emergency lane",
+        "q0416_o4": "special lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0417": {
+      "prompt": "Which of the following vehicle in front in the same lane is not allowed to be overtaken?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0417_o1": "the vehicle is reducing speed to yield",
+        "q0417_o2": "the vehicle is running normally",
+        "q0417_o3": "the vehicle is overtaking",
+        "q0417_o4": "the vehicle is making a stop"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0418": {
+      "prompt": "How to do in this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0418_o1": "wait in the cross-hatched marking area",
+        "q0418_o2": "stop and wait outside the intersection",
+        "q0418_o3": "follow the vehicle in front and pass",
+        "q0418_o4": "wait inside the intersection"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0419": {
+      "prompt": "What kind of violation does the red car have while temporarily stopping here?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0419_o1": "more than 30cm from roadside",
+        "q0419_o2": "stop in the section with no stopping marking",
+        "q0419_o3": "less than 30m from gas station",
+        "q0419_o4": "stop occupying the lane for non-motorized vehicles"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0420": {
+      "prompt": "Change driving license before of expiration.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0420_o1": "60 days",
+        "q0420_o2": "30 days",
+        "q0420_o3": "90 days",
+        "q0420_o4": "6 months"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0421": {
+      "prompt": "A motorized vehicle driver who does not hang the license plate is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0421_o1": "6-point penalty",
+        "q0421_o2": "12-point penalty",
+        "q0421_o3": "2-point penalty",
+        "q0421_o4": "3-point penalty"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0422": {
+      "prompt": "In which situation that a driver will not allowed to drive?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0422_o1": "penalty points reach 10 points",
+        "q0422_o2": "penalty points reach 6 points",
+        "q0422_o3": "driving license lost or destroyed",
+        "q0422_o4": "driving license is nearly expired"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0423": {
+      "prompt": "How to drive in sand, hail, rain, fog, ice and other weather conditions?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0423_o1": "run as normal",
+        "q0423_o2": "maintain the speed",
+        "q0423_o3": "speed up properly",
+        "q0423_o4": "reduce the speed"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0424": {
+      "prompt": "What causes the rear-end collision?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0424_o1": "not observe through the rear-view mirror while the vehicle in front brakes",
+        "q0424_o2": "the vehicle in front brakes suddenly",
+        "q0424_o3": "distance from the vehicle in front is too close when the rear vehicle overtakes",
+        "q0424_o4": "not maintain a safe distance from the vehicle in front"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0425": {
+      "prompt": "From which side to overtake?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0425_o1": "both sides",
+        "q0425_o2": "right side",
+        "q0425_o3": "left side",
+        "q0425_o4": "the side with no obstacle"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0426": {
+      "prompt": "How to drive through the intersection without traffic lights?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0426_o1": "reduce speed and go slowly",
+        "q0426_o2": "speed up and pass",
+        "q0426_o3": "let large vehicle go first",
+        "q0426_o4": "let the left vehicle go first"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0427": {
+      "prompt": "How to do in this situation?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0427_o1": "stop and yield to the pedestrians",
+        "q0427_o2": "bypass from the front of the pedestrians",
+        "q0427_o3": "honk to remind the pedestrians",
+        "q0427_o4": "bypass from the rear of the pedestrians"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0428": {
+      "prompt": "What kind of violation does this broken down vehicle have?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0428_o1": "not turn on the hazard lights",
+        "q0428_o2": "not stop the car by the roadside",
+        "q0428_o3": "not solve the problem at once",
+        "q0428_o4": "not place the warning sign"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0429": {
+      "prompt": "If a motorized vehicle breaks down or causes a traffic accident on the expressway and cannot to run normally, the vehicle should be towed by ______.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0429_o1": "a vehicle passing by",
+        "q0429_o2": "a large bus",
+        "q0429_o3": "a vehicle traveling together",
+        "q0429_o4": "a tow truck"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0430": {
+      "prompt": "In which situation the traffic police may detain the vehicle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0430_o1": "no vehicle registration papers",
+        "q0430_o2": "no insurance contract",
+        "q0430_o3": "no lable of environmental protection",
+        "q0430_o4": "no label of insurance"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0432": {
+      "prompt": "The age limit of applying for small vehicle is ________ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0432_o1": "18~60 years old",
+        "q0432_o2": "18~70 years old",
+        "q0432_o3": "24~70 years old",
+        "q0432_o4": "21~50 years old"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0433": {
+      "prompt": "Which is subject to a 12-point penalty?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0433_o1": "driving a motorized vehicle when driving license is temporarily detained",
+        "q0433_o2": "applying for reissuing the driving license by concealment or deception",
+        "q0433_o3": "not yielding to the school bus according to regulations",
+        "q0433_o4": "running with the license plate deliberately stained"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0434": {
+      "prompt": "The behavior of a motorized vehicle driver who has violated the law and regulations on road traffic safety is _______ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0434_o1": "faulty act",
+        "q0434_o2": "violation of regulations",
+        "q0434_o3": "rule-breaking act",
+        "q0434_o4": "violation of law"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0435": {
+      "prompt": "A driver who drives an illegally assembled motorized vehicle is subject to ______ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0435_o1": "being held for criminal liabilities according to law",
+        "q0435_o2": "a fine of 200 yuan ~ 2,000 yuan",
+        "q0435_o3": "being revoked the vehicle license",
+        "q0435_o4": "being detained for less than 15 days"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0436": {
+      "prompt": "In which situation that a driver cannot drive?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0436_o1": "after drinking coffee",
+        "q0436_o2": "after drinking milk",
+        "q0436_o3": "after drinking",
+        "q0436_o4": "after drinking tea"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0437": {
+      "prompt": "Besides the administrative punishment, what kind of system implemented by the traffic control department of the public security organ to the driver who violated the traffic regulations?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0437_o1": "violation registration system",
+        "q0437_o2": "mileage reward system",
+        "q0437_o3": "mandatory write-off system",
+        "q0437_o4": "accumulated penalty points system"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0438": {
+      "prompt": "What is the max speed on this highway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0438_o1": "30km/hr",
+        "q0438_o2": "40km/hr",
+        "q0438_o3": "50km/hr",
+        "q0438_o4": "70km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0439": {
+      "prompt": "Which of the following vehicle in front in the same lane is not allowed to be overtaken?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0439_o1": "large bus or large truck",
+        "q0439_o2": "taxis",
+        "q0439_o3": "ambulance on duty",
+        "q0439_o4": "public bus"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0440": {
+      "prompt": "Which of the following vehicle in front in the same lane is not allowed to be overtaken?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0440_o1": "large bus or large truck",
+        "q0440_o2": "fire engine on duty",
+        "q0440_o3": "public bus",
+        "q0440_o4": "taxis"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0441": {
+      "prompt": "A motorized vehicle that will turn right at an intersection but has a vehicle in front in the same lane waiting for the green light should ______________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0441_o1": "Stop and wait for his turn",
+        "q0441_o2": "Honk to indicate the vehicle in front to yield",
+        "q0441_o3": "Bypass the vehicle in front from the right side and go through the intersection",
+        "q0441_o4": "Bypass the vehicle in front from the left side and go through the intersection"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0442": {
+      "prompt": "How to turn right in this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0442_o1": "turn right directly",
+        "q0442_o2": "turn right at the front of the opposite car in advance",
+        "q0442_o3": "honk to urge",
+        "q0442_o4": "let the opposite car turn left first"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0443": {
+      "prompt": "How to do first when encountering such kind of bridge?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0443_o1": "maintain the speed and pass",
+        "q0443_o2": "speed up and pass as soon as possible",
+        "q0443_o3": "stop and observe",
+        "q0443_o4": "pass slowly"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0444": {
+      "prompt": "What kind of violation does this car have while stopping temporarily by the roadside?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0444_o1": "stop occupying the lane for motorized vehicles",
+        "q0444_o2": "stop more than 30cm from the roadside",
+        "q0444_o3": "stop in the section with no stopping marking",
+        "q0444_o4": "stop occupying the lane for non-motorized vehicles"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0445": {
+      "prompt": "If a driver has driven a motorized vehicle for more than four hours running, he should stop the vehicle and rest for at least ____________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0445_o1": "10 minutes",
+        "q0445_o2": "15 minutes",
+        "q0445_o3": "20 minutes",
+        "q0445_o4": "5 minutes"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0446": {
+      "prompt": "Which behavior a person had in 3 years is not allowed to apply for a motorized vehicle driving license?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0446_o1": "insulin injections",
+        "q0446_o2": "drunken experience",
+        "q0446_o3": "smoking addiction",
+        "q0446_o4": "drug injections"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0447": {
+      "prompt": "Within how long should a driver whose information has changed apply for new license?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0447_o1": "30 days",
+        "q0447_o2": "40 days",
+        "q0447_o3": "50 days",
+        "q0447_o4": "60 days"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0448": {
+      "prompt": "What is the time limit of deferred license checking due to military service, abroad and other reasons?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0448_o1": "3 years",
+        "q0448_o2": "5 years",
+        "q0448_o3": "1 years",
+        "q0448_o4": "2 years"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0449": {
+      "prompt": "A motorized vehicle driver who uses falsified and altered license plate is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0449_o1": "2-point penalty",
+        "q0449_o2": "3-point penalty",
+        "q0449_o3": "12-point penalty",
+        "q0449_o4": "6-point penalty"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0451": {
+      "prompt": "What does the traffic light mean?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0451_o1": "speed up and turn left",
+        "q0451_o2": "no right turn",
+        "q0451_o3": "intersection warning",
+        "q0451_o4": "speed and run straight"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0452": {
+      "prompt": "Which kind of vehicles are allowed to run in the lane with this marking on road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0452_o1": "public transport vehicles",
+        "q0452_o2": "private vehicles",
+        "q0452_o3": "taxis",
+        "q0452_o4": "official vehicles"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0453": {
+      "prompt": "How to use lights in this weather condition?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0453_o1": "use high beam lights",
+        "q0453_o2": "use fog lights",
+        "q0453_o3": "not use any light",
+        "q0453_o4": "turn on the right-turn signal"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0454": {
+      "prompt": "What is the max speed on this city road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0454_o1": "40km/hr",
+        "q0454_o2": "30km/hr",
+        "q0454_o3": "50km/hr",
+        "q0454_o4": "70km/hr"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0455": {
+      "prompt": "In which section when a vehicle runs is prohibited from overtaking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0455_o1": "elevated road",
+        "q0455_o2": "intersection",
+        "q0455_o3": "central streets",
+        "q0455_o4": "ring express"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0456": {
+      "prompt": "How to run in this situation?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0456_o1": "stop and yield to the opposite car",
+        "q0456_o2": "turn on the left-turn signal and run on the left side",
+        "q0456_o3": "turn on the head lights to let the other side yield",
+        "q0456_o4": "speed up to bypass the obstacle and then cross the other vehicle"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0457": {
+      "prompt": "When crossing each other at night, how far should change the high beam lights to low beam lights?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0457_o1": "not need to change lights",
+        "q0457_o2": "beyond 150m",
+        "q0457_o3": "within 100m",
+        "q0457_o4": "within 50m"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0458": {
+      "prompt": "How to do if there is a traffic jam in intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0458_o1": "borrow the opposite lane to pass",
+        "q0458_o2": "stop and wait outside the intersection",
+        "q0458_o3": "cut in the front vehicles to pass",
+        "q0458_o4": "enter the intersection and wait"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0459": {
+      "prompt": "How to do when the vehicle breaks down on road and needs to stop to solve the problem?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0459_o1": "stop in the middle of the road",
+        "q0459_o2": "stop the vehicle where will not interfere the traffic",
+        "q0459_o3": "turn on the low beam lights or fog lights",
+        "q0459_o4": "stop on the spot to solve the problem"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0460": {
+      "prompt": "What kind of violation does the vehicle have while temporarily stopping by the roadside?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0460_o1": "stop in the crosswalk",
+        "q0460_o2": "stop more than 30cm from the roadside",
+        "q0460_o3": "stop in the section with no stopping marking",
+        "q0460_o4": "stop occupying the lane for non-motorized vehicles"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0461": {
+      "prompt": "In which situation the traffic police may detain the vehicle on road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0461_o1": "not hang the license plate",
+        "q0461_o2": "no ID card",
+        "q0461_o3": "no insurance contract",
+        "q0461_o4": "no lable of environmental protection"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0462": {
+      "prompt": "A motorized vehicle driver who uses falsified and altered vehicle license is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0462_o1": "6-point penalty",
+        "q0462_o2": "3-point penalty",
+        "q0462_o3": "2-point penalty",
+        "q0462_o4": "12-point penalty"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0463": {
+      "prompt": "What should a motorized vehicle has while running on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0463_o1": "a label of keeping distance",
+        "q0463_o2": "a label of reminding danger",
+        "q0463_o3": "a label of inspection",
+        "q0463_o4": "a label of product qualification"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0464": {
+      "prompt": "How to run when encountering this situation at the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0464_o1": "stop and wait",
+        "q0464_o2": "obey the traffic lights",
+        "q0464_o3": "run straight on the right side",
+        "q0464_o4": "may turn right"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0465": {
+      "prompt": "How to use light in this situation at the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0465_o1": "turn off high beam lights",
+        "q0465_o2": "use hazard lights",
+        "q0465_o3": "use the high and low beam lights alternately",
+        "q0465_o4": "use high beam lights"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0466": {
+      "prompt": "How to use lights at night while crossing each other on narrow road or bridge?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0466_o1": "turn off all the lights",
+        "q0466_o2": "turn on the low beam lights",
+        "q0466_o3": "turn off the head lights",
+        "q0466_o4": "turn on high beam lights"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0467": {
+      "prompt": "How to choose parking spot when needing to stop by the roadside?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0467_o1": "stop in the opposite direction by the left roadside",
+        "q0467_o2": "stop in the parking area",
+        "q0467_o3": "stop anywhere as will by the roadside",
+        "q0467_o4": "stop in the sidewalk"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0468": {
+      "prompt": "Driving a small passenger vehicle at 100km/hr on the expressway, the minimum distance from the vehicle in front is _____ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0468_o1": "not less than 20 meters",
+        "q0468_o2": "not less than 10 meters",
+        "q0468_o3": "not less than 50 meters",
+        "q0468_o4": "not less than 30 meters"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0469": {
+      "prompt": "How to run at this position when leaving the expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0469_o1": "enter the deceleration lane",
+        "q0469_o2": "keep running forward",
+        "q0469_o3": "keep the speed at 100km/hr",
+        "q0469_o4": "reduce the speed to less than 40km/hr"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0470": {
+      "prompt": "How far away should the warning sign be placed in the coming direction when this vehicle breaks down and stops temporarily on the expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0470_o1": "beyond 150m",
+        "q0470_o2": "50~150m",
+        "q0470_o3": "within 50m",
+        "q0470_o4": "50~100m"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0471": {
+      "prompt": "If a motorized vehicle driver has caused a major traffic accident in violation of the traffic regulations which has caused human death due to his escaping, the driver is subject to a prison term of _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0471_o1": "less than 2 years",
+        "q0471_o2": "less than 3 years",
+        "q0471_o3": "less than 7 years",
+        "q0471_o4": "more than 7 years"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0472": {
+      "prompt": "In which situation the traffic police can detain the vehicle according to law?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0472_o1": "exceeding 10% of the prescribed speed limits",
+        "q0472_o2": "driving when he is exhausted",
+        "q0472_o3": "not buckled up while driving",
+        "q0472_o4": "driving after drinking"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0473": {
+      "prompt": "If the drivers household register has moved out of the original vehicle management station, the driver should apply to the vehicle management station _______ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0473_o1": "At the former place of his household register",
+        "q0473_o2": "At the residential place",
+        "q0473_o3": "At the new place of his household register",
+        "q0473_o4": "At the location of his household register"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0474": {
+      "prompt": "The cycle for recording the accumulated penalty points for violating road traffic regulations is __________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0474_o1": "14 months",
+        "q0474_o2": "12 months",
+        "q0474_o3": "6 months",
+        "q0474_o4": "10 months"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0475": {
+      "prompt": "Driving this kind of vehicle on road is ____",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0475_o1": "rule-breaking act",
+        "q0475_o2": "violation of regulations",
+        "q0475_o3": "violation of law",
+        "q0475_o4": "criminal act"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0476": {
+      "prompt": "What kind of violation does this vehicle on road have?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0476_o1": "not hang the license plate as required",
+        "q0476_o2": "deliberately cover the license plate",
+        "q0476_o3": "occupy the lane for non-motorized vehicles",
+        "q0476_o4": "run in the opposite direction"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0477": {
+      "prompt": "If the drivers accumulated penalty points reach the stipulated limit, he will be _______ by the traffic control department of the public security organ.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0477_o1": "detained for less than 15 days",
+        "q0477_o2": "banned for lifetime from driving",
+        "q0477_o3": "educated on the law and regulations and take the exam again",
+        "q0477_o4": "held for criminal liabilities according to law"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0478": {
+      "prompt": "How to pass when encountering this situation at the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0478_o1": "make sure it is safe to pass",
+        "q0478_o2": "turn right and speed up to pass",
+        "q0478_o3": "speed up and pass straight",
+        "q0478_o4": "turn left and speed up to pass"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0479": {
+      "prompt": "How to use lights when changing to the left lane on road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0479_o1": "turn on the right-turn signal in advance",
+        "q0479_o2": "not need to turn on any turn signal",
+        "q0479_o3": "turn on the left-turn signal in advance",
+        "q0479_o4": "turn on the low beam lights in advance"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0480": {
+      "prompt": "What is the max speed on this expressway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0480_o1": "110km/hr",
+        "q0480_o2": "120km/hr",
+        "q0480_o3": "90km/hr",
+        "q0480_o4": "100km/hr"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0481": {
+      "prompt": "What is the max speed on this highway?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0481_o1": "70km/hr",
+        "q0481_o2": "50km/hr",
+        "q0481_o3": "40km/hr",
+        "q0481_o4": "30km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0482": {
+      "prompt": "What is the max speed on a road covered by ice and snow",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0482_o1": "50km/hr",
+        "q0482_o2": "40km/hr",
+        "q0482_o3": "30km/hr",
+        "q0482_o4": "20km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0483": {
+      "prompt": "What should the driver do if conditions permit when a following vehicle gives the overtaking signal on a road without a central line?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0483_o1": "maintain the original speed",
+        "q0483_o2": "speed up",
+        "q0483_o3": "reduce speed, move to the right side and yield",
+        "q0483_o4": "immediately stop and yield"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0484": {
+      "prompt": "When encountering stopping in turn or slow-moving vehicles in front at an intersection where lanes are reduced, the motorized vehicle should _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0484_o1": "enter the intersection from road shoulder by the right side of the vehicle in front",
+        "q0484_o2": "enter the intersection from the side of interspace",
+        "q0484_o3": "pass alternately with one vehicle each lane to enter the intersection",
+        "q0484_o4": "change to left lane and cut in to enter the intersection"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0485": {
+      "prompt": "How to use lights at this position?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0485_o1": "turn on the right-turn signal",
+        "q0485_o2": "turn on the left-turn signal",
+        "q0485_o3": "turn on the hazard lights",
+        "q0485_o4": "turn on the head lights"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0486": {
+      "prompt": "What dangerous acts cant the driver conduct when driving downhill?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0486_o1": "slide the vehicle in the neutral gear",
+        "q0486_o2": "driving in lower gear",
+        "q0486_o3": "braking to reduce speed",
+        "q0486_o4": "changing to the lower gear in advance"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0487": {
+      "prompt": "A motorized vehicle driver who drives after drinking is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0487_o1": "3-point penalty",
+        "q0487_o2": "2-point penalty",
+        "q0487_o3": "6-point penalty",
+        "q0487_o4": "12-point penalty"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0488": {
+      "prompt": "When driving during the period of probation, the driver should paste or hang _____ on the rear part of the vehicle",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0488_o1": "a mark of avoiding with care",
+        "q0488_o2": "a mark of paying attention of beginner",
+        "q0488_o3": "a uniform probation mark",
+        "q0488_o4": "a mark of paying attention of vehicle distance"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0489": {
+      "prompt": "If one drives an illegally assembled motorized vehicle, he should not only pay the fine, but also ______ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0489_o1": "be confiscated the driving license",
+        "q0489_o2": "be revoked the driving permission",
+        "q0489_o3": "be forced to recover the vehicle condition",
+        "q0489_o4": "be revoked the driving license"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0490": {
+      "prompt": "How to pass this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0490_o1": "not reduce speed to pass",
+        "q0490_o2": "speed up to pass as soon as possible",
+        "q0490_o3": "slide over in the neutral gear",
+        "q0490_o4": "reduce speed or stop to observe"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0491": {
+      "prompt": "How to do when encountering this situation of waiting in line?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0491_o1": "cross the solid line from left side to overtake",
+        "q0491_o2": "overtake from both sides as will",
+        "q0491_o3": "wait in line",
+        "q0491_o4": "borrow the lane from right side to overtake"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0492": {
+      "prompt": "When encountering stopping and waiting in turn or slow-moving vehicles in front, the motorized vehicle may _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0492_o1": "borrow road to overtake",
+        "q0492_o2": "occupy the opposite lane",
+        "q0492_o3": "follow the vehicles in front",
+        "q0492_o4": "cut in the waiting vehicles"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0493": {
+      "prompt": "What kind of violation does this stopping car have?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0493_o1": "stop occupying the lane for non-motorized vehicles",
+        "q0493_o2": "stop in the section with no stopping marking",
+        "q0493_o3": "stop at bus station",
+        "q0493_o4": "stop occupying sidewalk"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0494": {
+      "prompt": "A motorized vehicle driver who drives the vehicle which permission is different is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0494_o1": "2-point penalty",
+        "q0494_o2": "3-point penalty",
+        "q0494_o3": "6-point penalty",
+        "q0494_o4": "12-point penalty"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0495": {
+      "prompt": "A motorized vehicle driver who escapes after causing a traffic accident but his conduct does not constitute a crime, is subject to a ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0495_o1": "3-point penalty",
+        "q0495_o2": "2-point penalty",
+        "q0495_o3": "12-point penalty",
+        "q0495_o4": "6-point penalty"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0496": {
+      "prompt": "If a person escapes after causing a traffic accident and constitutes a crime, his driving license should be revoked and he is banned _____ from re-obtaining a driving license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0496_o1": "within 5 years",
+        "q0496_o2": "within 10 years",
+        "q0496_o3": "within 20 years",
+        "q0496_o4": "for lifetime"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0497": {
+      "prompt": "Which is correct to use lights on rainy day when following a vehicle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0497_o1": "use high beam lights",
+        "q0497_o2": "cannot use the low beam lights",
+        "q0497_o3": "cannot use the high beam light",
+        "q0497_o4": "use fog lights"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0498": {
+      "prompt": "What is the max speed when in or out of the lane for non-motorized vehicles?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0498_o1": "40km/hr",
+        "q0498_o2": "50km/hr",
+        "q0498_o3": "60km/hr",
+        "q0498_o4": "30km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0499": {
+      "prompt": "In which situation cannot overtake a vehicle in front?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0499_o1": "vehicle in front is reducing speed to yield",
+        "q0499_o2": "vehicle in front is turning left",
+        "q0499_o3": "vehicle in front is pulling over by the roadside",
+        "q0499_o4": "vehicle in front is turning right"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0500": {
+      "prompt": "In which section cannot overtake?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0500_o1": "main streets",
+        "q0500_o2": "elevated road",
+        "q0500_o3": "crosswalk",
+        "q0500_o4": "ring express"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0501": {
+      "prompt": "In which section cannot overtake?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0501_o1": "mountain road",
+        "q0501_o2": "urban elevated road",
+        "q0501_o3": "urban expressway",
+        "q0501_o4": "narrow bridge and curve"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0502": {
+      "prompt": "What should the driver do when encountering a vehicle from the opposite direction on a road without a central line?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0502_o1": "driving closely by the roadside",
+        "q0502_o2": "driving by the central of the road",
+        "q0502_o3": "reducing speed and driving by right side",
+        "q0502_o4": "run by using the lane for non-motorized vehicles"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0503": {
+      "prompt": "How to pass the intersection when running straight",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0503_o1": "turn on the hazard lights and pass",
+        "q0503_o2": "directly speed up and pass straight",
+        "q0503_o3": "yield to the vehicle from the right road",
+        "q0503_o4": "yield to the vehicle from the left road"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0504": {
+      "prompt": "How to pass through the unmanned level crossing without traffic lights?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0504_o1": "properly reduce speed to pass",
+        "q0504_o2": "slide over in the neutral gear",
+        "q0504_o3": "stop to make sure it is safe, then pass",
+        "q0504_o4": "speed up and pass as fast as possible"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0505": {
+      "prompt": "What is the minimum speed in this lane?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0505_o1": "60km/hr",
+        "q0505_o2": "90km/hr",
+        "q0505_o3": "100km/hr",
+        "q0505_o4": "110km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0506": {
+      "prompt": "The driver who chases and races while driving on the road, and commits serious acts is subject to ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0506_o1": "a prison term of 6 months",
+        "q0506_o2": "a prison term of more than 1 year",
+        "q0506_o3": "a criminal restriction and a fine",
+        "q0506_o4": "a criminal detention and a fine"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0507": {
+      "prompt": "The driver who drives after drunk is subject to ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0507_o1": "a criminal restriction and a fine",
+        "q0507_o2": "a prison term of more than 2 years",
+        "q0507_o3": "a criminal detention and a fine",
+        "q0507_o4": "a prison term of less than 2 years"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0508": {
+      "prompt": "How long is the period of probation after a motorized vehicle driver obtains his driving license for the first time or the permission to drive higher level vehicles.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0508_o1": "6 months",
+        "q0508_o2": "12 months",
+        "q0508_o3": "2 years",
+        "q0508_o4": "3 months"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0509": {
+      "prompt": "How to use lights when pulling over on road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0509_o1": "turn on the hazard lights",
+        "q0509_o2": "turn on the right-turn signal in advance",
+        "q0509_o3": "use the high and low beam lights alternately",
+        "q0509_o4": "not need to use any light to indicate"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0510": {
+      "prompt": "What is the max speed on this city road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0510_o1": "30km/hr",
+        "q0510_o2": "40km/hr",
+        "q0510_o3": "50km/hr",
+        "q0510_o4": "70km/hr"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0511": {
+      "prompt": "How to use lights when overtaking at night?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0511_o1": "turn off the high beam light",
+        "q0511_o2": "turn on high beam lights",
+        "q0511_o3": "use fog lights",
+        "q0511_o4": "using the high and low beam lights alternately"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0512": {
+      "prompt": "How to cross each other on a narrow mountain road without the central dividing line?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0512_o1": "The vehicle not close to the mountain goes first",
+        "q0512_o2": "The vehicle close to the mountain goes first",
+        "q0512_o3": "The empty vehicle goes first",
+        "q0512_o4": "The slow-moving vehicle goes first"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0513": {
+      "prompt": "A motorized vehicle is not allowed to stop in the section within",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0513_o1": "5m",
+        "q0513_o2": "10m",
+        "q0513_o3": "50m",
+        "q0513_o4": "30m"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0514": {
+      "prompt": "May not drive if _____",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0514_o1": "the window is not closed",
+        "q0514_o2": "the door is not closed",
+        "q0514_o3": "the audio device is not closed",
+        "q0514_o4": "the roof window is not closed"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0515": {
+      "prompt": "If a motorized vehicle driver escapes after causing a major traffic accident which has caused human death, the driver is subject to a prison term of ________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0515_o1": "more than 7 years",
+        "q0515_o2": "less than 3 years",
+        "q0515_o3": "3 ~ 7 years",
+        "q0515_o4": "more than 10 years"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0516": {
+      "prompt": "If a person who has caused a major traffic accident and if his act constitutes a crime, he should be held for _________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0516_o1": "criminal liability",
+        "q0516_o2": "civil liability",
+        "q0516_o3": "direct liability",
+        "q0516_o4": "economic liability"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0517": {
+      "prompt": "Which should be taken along while driving?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0517_o1": "vocational qualification certificate",
+        "q0517_o2": "ID card",
+        "q0517_o3": "driving license",
+        "q0517_o4": "work permits"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0519": {
+      "prompt": "How to turn left at this intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0519_o1": "along the right side of the center point in the intersection",
+        "q0519_o2": "along the left side of the center point in the intersection",
+        "q0519_o3": "cover the center point in the intersection",
+        "q0519_o4": "can not turn left"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0520": {
+      "prompt": "How to do when encountering slow-moving vehicles in front?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0520_o1": "follow the vehicles in front",
+        "q0520_o2": "occupy the opposite lane to overtake",
+        "q0520_o3": "borrow the lane from right side to overtake",
+        "q0520_o4": "overtake from both sides as will"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0521": {
+      "prompt": "Which is subject to a 6-point penalty?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0521_o1": "use other vehicles vehicle license",
+        "q0521_o2": "run 50% faster than the prescribed speed limit",
+        "q0521_o3": "illegally occupy emergency lane",
+        "q0521_o4": "drive after drinking"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0522": {
+      "prompt": "The braking system may malfunction if it lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0523": {
+      "prompt": "The doors of both sides are not closed if it lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0524": {
+      "prompt": "When the light switch is rotated to the position, the whole car lights turn on.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0525": {
+      "prompt": "The light switch is in this position, front fog lights turn on",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0526": {
+      "prompt": "It displays the current engine speed is 6000 rev / min.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0527": {
+      "prompt": "The oil pressure of engine may be too high if it lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0528": {
+      "prompt": "It lights when turning on the front high beam lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0529": {
+      "prompt": "Pull down the switch of the turn signal, right-turn signal is on.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0530": {
+      "prompt": "Move the switch up and down, the windscreen wipers start working.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0531": {
+      "prompt": "The safety pillow is used to protect the driver's head when there is a rear-end collision.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0532": {
+      "prompt": "Driving motor vehicle with ABS system may occur side skidding when applying emergency braking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0533": {
+      "prompt": "When the motor vehicle installed ABS system brakes, the braking distance will be greatly shortened, so you do not have to keep a safe distance between vehicles.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0534": {
+      "prompt": "It lights when the handbrake is pulled up.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0535": {
+      "prompt": "It lights to remind that engine coolant may be insufficient.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0536": {
+      "prompt": "It flashes when breaking down.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0537": {
+      "prompt": "It lights if left door is not closed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0538": {
+      "prompt": "Steering wheel will be locked if removing the key while the ignition switch is in the LOCK position.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0539": {
+      "prompt": "When ignition switch is in the START position, the starter starts.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0540": {
+      "prompt": "When the motor vehicle installed ABS system applys emergency braking, the driver can depress the brake pedal heavily.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0541": {
+      "prompt": "Does not affect normal driving when it lights",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0542": {
+      "prompt": "It lights to remind that engine needs to add oil.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0543": {
+      "prompt": "It lights continuously to indicate that engine control system failed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0544": {
+      "prompt": "Motor vehicle frontal collision, the double protection of the airbag and the safety belts can give full play to the role.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0545": {
+      "prompt": "It lights continuously to indicate that airbag is working.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0546": {
+      "prompt": "It lights when turning on the right-turn signal.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0547": {
+      "prompt": "The rear windshield defroster starts to work after pressing this switch.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0548": {
+      "prompt": "It lights to indicate that engine compartment is opened.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0549": {
+      "prompt": "It lights when turning on the left-turn signal.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0550": {
+      "prompt": "Ignition switch in the ON position, the vehicle can not use electrical appliances.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0551": {
+      "prompt": "Displays the current speed is 20 km / h",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0552": {
+      "prompt": "It lights to indicate that right door is not closed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0553": {
+      "prompt": "Move the turn signal switch upward, the left-turn signal lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0554": {
+      "prompt": "It lights to indicate that luggage compartment is open.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0555": {
+      "prompt": "It lights when turning on the width light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0556": {
+      "prompt": "It lights when ABS is open.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0557": {
+      "prompt": "It lights when turning on the front low beam lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0558": {
+      "prompt": "The starter works when turning the ignition switch to the ACC position.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0559": {
+      "prompt": "It lights to indicate that engine oil may be insufficient.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0560": {
+      "prompt": "It lights to remind that engine oil needs to be filled.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0561": {
+      "prompt": "To hold the steering wheel like this is correct.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0562": {
+      "prompt": "Rear fog light lights when the light switch is at this position.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0563": {
+      "prompt": "It lights when turning on the front fog light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0564": {
+      "prompt": "It lights to indicate that the generator is charging to the batteries.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0565": {
+      "prompt": "It lights when turning on the rear fog light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0566": {
+      "prompt": "The seat belts can reduce the injury of the driver and passengers when there is a collision.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0567": {
+      "prompt": "It displays that the current temperature of the coolant is 90 degrees.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0568": {
+      "prompt": "It displays that oil in tank has less than the warning line",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0569": {
+      "prompt": "It lights to indicate that the handbrake may not loose in the end.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0570": {
+      "prompt": "It lights to remind that the driver's seat is not adjusted properly.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0571": {
+      "prompt": "It lights to remind that the driver has not buckled up.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0572": {
+      "prompt": "It flashes when turning on the hazard lights.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0573": {
+      "prompt": "It lights to indicate enabling the floor and the front windscreen fan.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0574": {
+      "prompt": "ABS system can keep the steering capability of the front wheels while providing maximum braking force when the vehicle conduct an emergency braking.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0575": {
+      "prompt": "The vehicle with ABS system can minimize the braking distance when driving on a road covered by ice and snow.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0576": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0576_o1": "the tail fog light is turned on",
+        "q0576_o2": "the low beam light is turned on",
+        "q0576_o3": "the high beam light is turned on",
+        "q0576_o4": "the head fog light is turned on"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0577": {
+      "prompt": "What device does the switch of this symbol control?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0577_o1": "the windscreen defrosting or defogging",
+        "q0577_o2": "the rear window wiper and washer",
+        "q0577_o3": "the windscreen wiper and washer",
+        "q0577_o4": "the rear window defrosting or defogging"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0578": {
+      "prompt": "What is this manipulation device?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0578_o1": "the handbrake",
+        "q0578_o2": "the air throttle lever",
+        "q0578_o3": "the gear lever",
+        "q0578_o4": "the clutch lever"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0579": {
+      "prompt": "ABS system can maximize the braking efficiency when conducting _______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0579_o1": "braking intermittently",
+        "q0579_o2": "braking continuously",
+        "q0579_o3": "applying emergency braking",
+        "q0579_o4": "gently depressing the brake pedal"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0580": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0580_o1": "the tail fog light is turned on",
+        "q0580_o2": "the low beam light is turned on",
+        "q0580_o3": "the high beam light is turned on",
+        "q0580_o4": "the head fog light is turned on"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0581": {
+      "prompt": "What device does the switch of this symbol control?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0581_o1": "the windscreen wiper and washer",
+        "q0581_o2": "the rear window defrosting or defogging",
+        "q0581_o3": "the rear window wiper and washer",
+        "q0581_o4": "the windscreen defrosting or defogging"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0582": {
+      "prompt": "What is this manipulation device?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0582_o1": "switch of the turn signal",
+        "q0582_o2": "switch of the head lights",
+        "q0582_o3": "switch of wiper",
+        "q0582_o4": "switch of defogger"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0583": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0583_o1": "the tail fog light is turned on",
+        "q0583_o2": "the low beam light is turned on",
+        "q0583_o3": "the high beam light is turned on",
+        "q0583_o4": "the head fog light is turned on"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0584": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0584_o1": "charge current is too large",
+        "q0584_o2": "damaged battery",
+        "q0584_o3": "ammeter malfunction",
+        "q0584_o4": "charging circuit malfunction"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0585": {
+      "prompt": "What pedal is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0585_o1": "clutch pedal",
+        "q0585_o2": "accelerator pedal",
+        "q0585_o3": "brake pedal",
+        "q0585_o4": "handbrake"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0586": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0586_o1": "ABS system malfunction",
+        "q0586_o2": "handbrake is released",
+        "q0586_o3": "braking system malfunction",
+        "q0586_o4": "safety bags malfunction"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0587": {
+      "prompt": "What pedal is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0587_o1": "accelerator pedal",
+        "q0587_o2": "clutch pedal",
+        "q0587_o3": "handbrake",
+        "q0587_o4": "the brake pedal"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0588": {
+      "prompt": "What is this manipulation device?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0588_o1": "the air throttle lever",
+        "q0588_o2": "the gear lever",
+        "q0588_o3": "the clutch lever",
+        "q0588_o4": "the handbrake"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0589": {
+      "prompt": "What is the role of ABS system when applying emergency braking?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0589_o1": "cut off the power output",
+        "q0589_o2": "control the direction automatically",
+        "q0589_o3": "reduce braking inertia",
+        "q0589_o4": "prevent wheel blocking"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0590": {
+      "prompt": "What pedal is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0590_o1": "clutch pedal",
+        "q0590_o2": "brake pedal",
+        "q0590_o3": "handbrake",
+        "q0590_o4": "accelerator pedal"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0591": {
+      "prompt": "It lights continuously to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0591_o1": "safety bags work",
+        "q0591_o2": "not buckled up",
+        "q0591_o3": "ABS system malfunction",
+        "q0591_o4": "safety bags malfunction"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0592": {
+      "prompt": "What is this manipulation device?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0592_o1": "switch of windscreen wiper",
+        "q0592_o2": "switch of the head lights",
+        "q0592_o3": "switch of the turn signal",
+        "q0592_o4": "switch of defogger"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0593": {
+      "prompt": "What kind of device the safety bags are?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0593_o1": "ABS system",
+        "q0593_o2": "electronic brake force distribution system",
+        "q0593_o3": "assisted occupants protection system",
+        "q0593_o4": "drivers head and neck protection system"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0594": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0594_o1": "left-turn signal flashes",
+        "q0594_o2": "front and rear width lights light on",
+        "q0594_o3": "front and rear width lights light on",
+        "q0594_o4": "right-turn signal flashes"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0595": {
+      "prompt": "The front safety bags play a fully protective role when used in conjunction with ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0595_o1": "ABS system",
+        "q0595_o2": "seat belt",
+        "q0595_o3": "safety pillow of the chair",
+        "q0595_o4": "safety glasses"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0596": {
+      "prompt": "The hazard lights can be used when ________",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0596_o1": "encountering traffic congestion",
+        "q0596_o2": "following a vehicle on road",
+        "q0596_o3": "the vehicle breaks down and stops",
+        "q0596_o4": "leading the vehicle behind"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0597": {
+      "prompt": "What does this symbol indicate?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0597_o1": "snowy starting mode",
+        "q0597_o2": "air circulation",
+        "q0597_o3": "air condition cooling mode",
+        "q0597_o4": "cooling or warming fan"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0598": {
+      "prompt": "What does this symbol indicate?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0598_o1": "switch of high beam lights",
+        "q0598_o2": "switch of the low beam lights",
+        "q0598_o3": "master switch of vehicle lights",
+        "q0598_o4": "the switch of tail fog light"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0599": {
+      "prompt": "What is this instrument?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0599_o1": "speed and mileage meter",
+        "q0599_o2": "engine tachometer",
+        "q0599_o3": "top speed meter",
+        "q0599_o4": "fuel consumption / 100 km"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0600": {
+      "prompt": "What is this instrument?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0600_o1": "pressure meter",
+        "q0600_o2": "ammeter",
+        "q0600_o3": "water temperature meter",
+        "q0600_o4": "fuel meter"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0601": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0601_o1": "ABS system malfunction",
+        "q0601_o2": "handbrake is released",
+        "q0601_o3": "braking system malfunction",
+        "q0601_o4": "handbrake is pulled up"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0602": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0602_o1": "engine compartment is opened",
+        "q0602_o2": "cover of fuel tank is opened",
+        "q0602_o3": "doors of both sides are opened",
+        "q0602_o4": "luggage compartment is opened"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0603": {
+      "prompt": "What device does the switch of this symbol control?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0603_o1": "the windscreen defrosting",
+        "q0603_o2": "the rear window wiper",
+        "q0603_o3": "the rear window defrosting",
+        "q0603_o4": "the windscreen wiper"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0604": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0604_o1": "handbrake released",
+        "q0604_o2": "foot brake failure",
+        "q0604_o3": "braking system is abnormal",
+        "q0604_o4": "the brake pedal does not return back"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0605": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0605_o1": "not buckled up",
+        "q0605_o2": "safety belt malfunction",
+        "q0605_o3": "the safety belts are too loose",
+        "q0605_o4": "buckled up already"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0606": {
+      "prompt": "What does this symbol indicate?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0606_o1": "luggage compartment is opened",
+        "q0606_o2": "engine compartment is opened",
+        "q0606_o3": "cover of fuel tank is opened",
+        "q0606_o4": "door of one side is opened"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0607": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0607_o1": "air internal circulation",
+        "q0607_o2": "air external circulation",
+        "q0607_o3": "the front fan works",
+        "q0607_o4": "windscreen defroster"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0608": {
+      "prompt": "What is this manipulation device?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0608_o1": "air conditioner switch",
+        "q0608_o2": "ignition switch",
+        "q0608_o3": "wiper switch",
+        "q0608_o4": "light switch"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0609": {
+      "prompt": "What is this instrument?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0609_o1": "engine tachometer",
+        "q0609_o2": "driving speed meter",
+        "q0609_o3": "interval mileage meter",
+        "q0609_o4": "fuel consumption / 100 km"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0610": {
+      "prompt": "What is this instrument?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0610_o1": "water temperature meter",
+        "q0610_o2": "fuel meter",
+        "q0610_o3": "ammeter",
+        "q0610_o4": "pressure meter"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0611": {
+      "prompt": "After starting the engine, it lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0611_o1": "engine main oil way blockage",
+        "q0611_o2": "engine oil pressure is too low",
+        "q0611_o3": "engine crankshaft box leaks",
+        "q0611_o4": "engine oil pressure is too high"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0612": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0612_o1": "the head fog light is turned on",
+        "q0612_o2": "the low beam light is turned on",
+        "q0612_o3": "the high beam light is turned on",
+        "q0612_o4": "the tail fog light is turned on"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0613": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0613_o1": "the floor and the front fans work",
+        "q0613_o2": "air internal circulation",
+        "q0613_o3": "air external circulation",
+        "q0613_o4": "the side and the floor fans work"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0614": {
+      "prompt": "What device does the switch of this symbol control?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0614_o1": "child safety lock",
+        "q0614_o2": "window glasses of both sides",
+        "q0614_o3": "electric door",
+        "q0614_o4": "door unlock"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0615": {
+      "prompt": "Which part does this switch control?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0615_o1": "windscreen defogger",
+        "q0615_o2": "windscreen wiper",
+        "q0615_o3": "the hazard lights",
+        "q0615_o4": "devices of lights and signals"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0616": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0616_o1": "the hazard lights flash",
+        "q0616_o2": "right-turn signal flashes",
+        "q0616_o3": "left-turn signal flashes",
+        "q0616_o4": "front and rear width lights flash"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0617": {
+      "prompt": "What does this symbol indicate?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0617_o1": "luggage compartment is opened",
+        "q0617_o2": "door of one side is opened",
+        "q0617_o3": "engine compartment is opened",
+        "q0617_o4": "cover of fuel tank is opened"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0618": {
+      "prompt": "What is this manipulation device?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0618_o1": "switch of reverse light",
+        "q0618_o2": "switch of wiper",
+        "q0618_o3": "switch of the hazard lights",
+        "q0618_o4": "combination switch of lights and signals"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0619": {
+      "prompt": "Which part does it control when pulling this switch?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0619_o1": "turn signals",
+        "q0619_o2": "reverse light",
+        "q0619_o3": "contour light",
+        "q0619_o4": "hazard light"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0620": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0620_o1": "the head and tail fog lights are turned on",
+        "q0620_o2": "front and rear width lights are turned on",
+        "q0620_o3": "the head lights are turned on",
+        "q0620_o4": "the hazard lights are turned on"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0621": {
+      "prompt": "After starting the engine, it lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0621_o1": "fuel pump abnormal or malfunction",
+        "q0621_o2": "ignition system malfunction",
+        "q0621_o3": "fuel supply system is abnormal",
+        "q0621_o4": "fuel in tank reaches the minimum level"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0622": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0622_o1": "front and rear width lights light on",
+        "q0622_o2": "front and rear width lights light on",
+        "q0622_o3": "left-turn signal flashes",
+        "q0622_o4": "right-turn signal flashes"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0623": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0623_o1": "the front fan works",
+        "q0623_o2": "air external circulation",
+        "q0623_o3": "windscreen defroster",
+        "q0623_o4": "air internal circulation"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0624": {
+      "prompt": "What device does the switch of this symbol control?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0624_o1": "window glasses of both sides",
+        "q0624_o2": "electric door",
+        "q0624_o3": "door unlock",
+        "q0624_o4": "child safety lock"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0625": {
+      "prompt": "Which part of the driver can be protected by the safety pillow when there is a rear-end collision?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0625_o1": "waist",
+        "q0625_o2": "chest",
+        "q0625_o3": "head",
+        "q0625_o4": "neck"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0626": {
+      "prompt": "What is the main role of the seat belt when there is a collision?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0626_o1": "to protect the driver and passengers necks",
+        "q0626_o2": "to protect the driver and passengers chests",
+        "q0626_o3": "to reduce the injuries of the driver and passengers",
+        "q0626_o4": "to protect the driver and passengers waists"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0627": {
+      "prompt": "It lights while driving to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0627_o1": "engine temperature is too high",
+        "q0627_o2": "engine cooling system malfunction",
+        "q0627_o3": "engine lubrication system malfunction",
+        "q0627_o4": "engine temperature is too low"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0628": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0628_o1": "the side fans work",
+        "q0628_o2": "air external circulation",
+        "q0628_o3": "the front fan works",
+        "q0628_o4": "air internal circulation"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0629": {
+      "prompt": "It lights to indicate that ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0629_o1": "windscreen wash lacks",
+        "q0629_o2": "braking oil lacks",
+        "q0629_o3": "cooling system malfunction",
+        "q0629_o4": "coolant lacks"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0630": {
+      "prompt": "Which part does it control when rotating this part of the switch?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0630_o1": "the low beam lights",
+        "q0630_o2": "the head and tail fog lights",
+        "q0630_o3": "high beam lights",
+        "q0630_o4": "turn signals"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0631": {
+      "prompt": "At this position, the motorized vehicle can continue to go through if the front wheels have passed the stop line.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0632": {
+      "prompt": "The vehicles are prohibited from passing when encountering this traffic light at the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0633": {
+      "prompt": "Pass the crossing as fast as possible if there is a red light at the intersection of a road or a level crossing.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0634": {
+      "prompt": "Reduce speed or stop to look before the stop line when encountering this traffic light at the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0635": {
+      "prompt": "Speed up and pass when encountering this traffic light at the intersection",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0636": {
+      "prompt": "Continue to go through if having passed the stop line when encountering this traffic light at the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0637": {
+      "prompt": "The vehicle can not run straight or turn left in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0638": {
+      "prompt": "May directly turn left in front of the vehicle coming opposite when encountering this traffic light.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0639": {
+      "prompt": "No turning left in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0640": {
+      "prompt": "May turn right in this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0641": {
+      "prompt": "No turning right at the intersection ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0642": {
+      "prompt": "The red car can run in this lane.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0643": {
+      "prompt": "May turn right when encountering this traffic light at the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0644": {
+      "prompt": "No running into the middle lane when encountering this situation.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0645": {
+      "prompt": "The vehicle is allowed to pass the intersection ahead when the green light on.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0646": {
+      "prompt": "Choose the lane with the green arrow light on.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0647": {
+      "prompt": "The continuously flashing yellow light means that the vehicle may speed up and pass.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0648": {
+      "prompt": "The continuously flashing yellow light is to warn that the driver should look and make sure it is safe to pass.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0649": {
+      "prompt": "When the two red lights at a level crossing flash alternately, the vehicles should stop to wait.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0650": {
+      "prompt": "No turning right when encountering this traffic light at the intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0651": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0651_o1": "emergency shelter",
+        "q0651_o2": "service area",
+        "q0651_o3": "pedestrian passage",
+        "q0651_o4": "crossing road facility"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0652": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0652_o1": "national boundaries",
+        "q0652_o2": "border defense",
+        "q0652_o3": "boundaries",
+        "q0652_o4": "customs"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0653": {
+      "prompt": "What’s the meaning of these white rectangle markings?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0653_o1": "long time parking",
+        "q0653_o2": "time limited parking",
+        "q0653_o3": "free parking",
+        "q0653_o4": "special parking"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0654": {
+      "prompt": "What marking is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0654_o1": "prohibitive area",
+        "q0654_o2": "cross-hatched marking",
+        "q0654_o3": "guide line",
+        "q0654_o4": "central circle"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0655": {
+      "prompt": "What’s the meaning of this yellow sign on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0655_o1": "no U turn",
+        "q0655_o2": "no left turn",
+        "q0655_o3": "no right turn",
+        "q0655_o4": "no going straight"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0656": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0656_o1": "reduce speed and yield",
+        "q0656_o2": "variable lane",
+        "q0656_o3": "separated road",
+        "q0656_o4": "two-way traffic"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0657": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0657_o1": "no honking the tweeter",
+        "q0657_o2": "no honking the woofer",
+        "q0657_o3": "should honk",
+        "q0657_o4": "no honking"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0658": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0658_o1": "crosswalk",
+        "q0658_o2": "students passage",
+        "q0658_o3": "watch for pedestrians",
+        "q0658_o4": "children's passage"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0659": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0659_o1": "provincial highway No.",
+        "q0659_o2": "national highway No.",
+        "q0659_o3": "county road No.",
+        "q0659_o4": "township road No."
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0660": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0660_o1": "indication of the place name of the expressway ending",
+        "q0660_o2": "indication of the driving route of the expressway",
+        "q0660_o3": "indication of the driving direction of the expressway",
+        "q0660_o4": "indication of the location and distance of the expressway"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0661": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0661_o1": "expressway exit ahead",
+        "q0661_o2": "expressway entry ahead",
+        "q0661_o3": "expressway ending ahead",
+        "q0661_o4": "expressway beginning ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0662": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0662_o1": "payment lane on the expressway",
+        "q0662_o2": "check lane on the expressway",
+        "q0662_o3": "card getting lane on the expressway",
+        "q0662_o4": "ETC lane on the expressway"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0663": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0663_o1": "expressway parking area ahead",
+        "q0663_o2": "expressway shelter ahead",
+        "q0663_o3": "expressway car park ahead",
+        "q0663_o4": "expressway service area ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0664": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0664_o1": "bump road",
+        "q0664_o2": "low-lying road",
+        "q0664_o3": "high outburst road",
+        "q0664_o4": "hump bridge"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0665": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0665_o1": "Passing on both sides",
+        "q0665_o2": "Passing by the right side",
+        "q0665_o3": "Passing by the left side",
+        "q0665_o4": "Passing is prohibited"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0666": {
+      "prompt": "The yellow lane-dividing line on the road is used to _____",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0666_o1": "allow to drive in left lane",
+        "q0666_o2": "separate the traffic flow in opposite directions",
+        "q0666_o3": "separate the traffic flow in the same direction",
+        "q0666_o4": "prohibit to cross the opposite lane"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0667": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0667_o1": "watch for pedestrians",
+        "q0667_o2": "crosswalk",
+        "q0667_o3": "village or town",
+        "q0667_o4": "primary school"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0668": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0668_o1": "section narrows on both sides",
+        "q0668_o2": "section for speed test",
+        "q0668_o3": "section for ascertaining the distance between the vehicles",
+        "q0668_o4": "pay attentions to keeping distance"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0669": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0669_o1": "no changing lane",
+        "q0669_o2": "no left turn",
+        "q0669_o3": "no going straight",
+        "q0669_o4": "no U turn"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0670": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0670_o1": "left-turn lane",
+        "q0670_o2": "straight-going lane",
+        "q0670_o3": "right-turn lane",
+        "q0670_o4": "lanes for going in different directions"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0671": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0671_o1": "Road traffic flow monitoring",
+        "q0671_o2": "Deceleration photographed area",
+        "q0671_o3": "Full section snapshot",
+        "q0671_o4": "Traffic monitoring equipment"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0672": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0672_o1": "the distance from the tunnel exit",
+        "q0672_o2": "the distance from the tunnel entry",
+        "q0672_o3": "the distance of following the vehicle in front in the tunnel",
+        "q0672_o4": "the whole length of the tunnel"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0673": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0673_o1": "expressway left exit ahead",
+        "q0673_o2": "expressway destination ahead",
+        "q0673_o3": "expressway right exit ahead",
+        "q0673_o4": "expressway next exit ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0674": {
+      "prompt": "What’s the meaning of the white solid lines at the edge of the carriageway on both sides of the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0674_o1": "Vehicles may cross temporarily",
+        "q0674_o2": "Vehicles are not allowed to cross.",
+        "q0674_o3": "Motorized vehicles may cross temporarily.",
+        "q0674_o4": "Non-motorized vehicles may cross temporarily"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0675": {
+      "prompt": "What marking is the white semicircle in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0675_o1": "driving at reduced speed",
+        "q0675_o2": "ascertaining the vehicles speed",
+        "q0675_o3": "reducing the speed at the intersection",
+        "q0675_o4": "ascertaining the distance between the vehicles"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0676": {
+      "prompt": "What’s the meaning of the white broken lines area on the far left side?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0676_o1": "special lane for multi-passenger vehicles",
+        "q0676_o2": "special lane for small buses",
+        "q0676_o3": "special lane for taxis with no passenger",
+        "q0676_o4": "special lane for large buses"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0677": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ____ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0677_o1": "turn right",
+        "q0677_o2": "change lane",
+        "q0677_o3": "reduce speed and pass slowly",
+        "q0677_o4": "pull over"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0678": {
+      "prompt": "The vehicle is allowed to _______ at this intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0678_o1": "go straight",
+        "q0678_o2": "turn right",
+        "q0678_o3": "turn left",
+        "q0678_o4": "go straight or turn left"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0679": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0679_o1": "continuous down slopes",
+        "q0679_o2": "steep downhill road",
+        "q0679_o3": "steep uphill road",
+        "q0679_o4": "continuous up slopes"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0680": {
+      "prompt": "What is this traffic sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0680_o1": "Road narrows on both sides",
+        "q0680_o2": "Road narrows on the right side",
+        "q0680_o3": "Road narrows on the left side",
+        "q0680_o4": "Bridge narrows"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0681": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0681_o1": "muddy road",
+        "q0681_o2": "low-lying road",
+        "q0681_o3": "overflowing road",
+        "q0681_o4": "ferry"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0682": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0682_o1": "an unmanned level crossing 100m ahead",
+        "q0682_o2": "a manned level crossing 100m ahead",
+        "q0682_o3": "an unmanned level crossing 50m ahead",
+        "q0682_o4": "a manned level crossing 50m ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0683": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0683_o1": "no going straight and no changing to left lane",
+        "q0683_o2": "no going straight and no left turn",
+        "q0683_o3": "allowed to go straight and turn left",
+        "q0683_o4": "no going straight and no right turn"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0684": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0684_o1": "3m width limit ahead",
+        "q0684_o2": "3m width limit",
+        "q0684_o3": "the 3m width limit ban is lifted",
+        "q0684_o4": "3m height limit"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0685": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0685_o1": "turn left",
+        "q0685_o2": "no going straight",
+        "q0685_o3": "straight-going lane",
+        "q0685_o4": "one-way road"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0686": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0686_o1": "lane for small vehicles",
+        "q0686_o2": "special lane for small vehicles",
+        "q0686_o3": "special lane for multi-passenger vehicles",
+        "q0686_o4": "lane for motorized vehicles"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0687": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0687_o1": "provincial highway No.",
+        "q0687_o2": "county road No.",
+        "q0687_o3": "township road No.",
+        "q0687_o4": "national highway No."
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0688": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0688_o1": "police call number on expressway",
+        "q0688_o2": "public phone on expressway",
+        "q0688_o3": "emergency call number on expressway",
+        "q0688_o4": "rescue call number on expressway"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0689": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0689_o1": "bus station of expressway",
+        "q0689_o2": "rest area of expressway",
+        "q0689_o3": "gasoline station of expressway",
+        "q0689_o4": "service area of expressway"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0690": {
+      "prompt": "What marking is the two white broken lines in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0690_o1": "stop lines at crossroad",
+        "q0690_o2": "left-turn waiting areas",
+        "q0690_o3": "U turn guide lines",
+        "q0690_o4": "small vehicles turning lines"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0691": {
+      "prompt": "What’s the meaning of the white rectangle marking?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0691_o1": "special space for taxicabs to take and drop passengers",
+        "q0691_o2": "horizontal parking space",
+        "q0691_o3": "inclined parking space",
+        "q0691_o4": "vertical parking space"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0692": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ____ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0692_o1": "reduce speed and pass slowly",
+        "q0692_o2": "pull over",
+        "q0692_o3": "stop",
+        "q0692_o4": "turn right"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0693": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0693_o1": "Y-shaped intersection",
+        "q0693_o2": "T-shaped intersection",
+        "q0693_o3": "intersection",
+        "q0693_o4": "ring intersection"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0694": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0694_o1": "hump bridge",
+        "q0694_o2": "high outburst road",
+        "q0694_o3": "low-lying road",
+        "q0694_o4": "bump road"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0695": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0695_o1": "no U turn",
+        "q0695_o2": "no changing to left lane",
+        "q0695_o3": "no turning left",
+        "q0695_o4": "no entering the left lane"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0696": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0696_o1": "overtaking ban is lifted",
+        "q0696_o2": "changing lane is allowed",
+        "q0696_o3": "changing lane ban is lifted",
+        "q0696_o4": "borrowing lane ban is lifted"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0697": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0697_o1": "customs inspection",
+        "q0697_o2": "stop-for-inspection",
+        "q0697_o3": "frontier inspection",
+        "q0697_o4": "no passing"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0698": {
+      "prompt": "What’s the role of indicative sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0698_o1": "tell the direction information",
+        "q0698_o2": "warn danger ahead",
+        "q0698_o3": "restrict the vehicles and pedestrians from passing",
+        "q0698_o4": "indicate the vehicles and pedestrians to go ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0699": {
+      "prompt": "What’s the role of directional sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0699_o1": "restrict the vehicles from passing",
+        "q0699_o2": "indicate speed limited information",
+        "q0699_o3": "provide direction information",
+        "q0699_o4": "warn danger ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0700": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0700_o1": "intersection ahead",
+        "q0700_o2": "interchange ahead",
+        "q0700_o3": "Y-shaped intersection ahead",
+        "q0700_o4": "ring intersection ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0701": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0701_o1": "observation deck",
+        "q0701_o2": "car park",
+        "q0701_o3": "rest area",
+        "q0701_o4": "parking space"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0702": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0702_o1": "recommended speed in unusual weather",
+        "q0702_o2": "minimum speed in unusual weather",
+        "q0702_o3": "average speed in unusual weather",
+        "q0702_o4": "maximum speed in unusual weather"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0703": {
+      "prompt": "Which kind of sign is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0703_o1": "tourist zone sign",
+        "q0703_o2": "work area sign",
+        "q0703_o3": "notification signs",
+        "q0703_o4": "expressway sign"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0704": {
+      "prompt": "What marking are the white broken lines in the circles?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0704_o1": "small vehicles turning lines",
+        "q0704_o2": "lane connection lines",
+        "q0704_o3": "non-motorized vehicles guide lines",
+        "q0704_o4": "intersection guide line"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0705": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0705_o1": "indicate going straight or turning right",
+        "q0705_o2": "indicate turning right or making a U turn",
+        "q0705_o3": "indicate going straight or changing to right lane",
+        "q0705_o4": "indicate going straight or making a U turn"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0706": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0706_o1": "indicate changing to left lane",
+        "q0706_o2": "indicate changing to left lane",
+        "q0706_o3": "indicate making a U turn ahead",
+        "q0706_o4": "indicate turning right ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0707": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0707_o1": "indicate turning left or making a U turn ahead",
+        "q0707_o2": "indicate going straight or turning left ahead",
+        "q0707_o3": "indicate going straight or changing to left lane ahead",
+        "q0707_o4": "indicate going straight or making a U turn ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0708": {
+      "prompt": "What’s the meaning of this figure mark on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0708_o1": "a mark of keeping distance",
+        "q0708_o2": "a mark of minimum distance",
+        "q0708_o3": "a mark of speed limit",
+        "q0708_o4": "a mark of road number"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0709": {
+      "prompt": "What’s the meaning of the yellow solid line on the curbstone?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0709_o1": "only for taking and dropping people",
+        "q0709_o2": "only for loading and unloading cargos",
+        "q0709_o3": "no long stopping",
+        "q0709_o4": "no parking"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0710": {
+      "prompt": "Which kind of sign is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0710_o1": "warning sign",
+        "q0710_o2": "directional sign",
+        "q0710_o3": "indicative sign",
+        "q0710_o4": "prohibitive sign"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0711": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0711_o1": "bypass from left side",
+        "q0711_o2": "continuous curves",
+        "q0711_o3": "sharp left curve",
+        "q0711_o4": "sharp right curve"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0712": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0712_o1": "watch for pedestrians",
+        "q0712_o2": "watch for children",
+        "q0712_o3": "school area",
+        "q0712_o4": "crosswalk"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0713": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0713_o1": "watch for wildlife",
+        "q0713_o2": "watch for animals",
+        "q0713_o3": "zoo park",
+        "q0713_o4": "opened pastoral area"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0714": {
+      "prompt": "Which kind of sign is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0714_o1": "warning sign",
+        "q0714_o2": "prohibitive sign",
+        "q0714_o3": "indicative sign",
+        "q0714_o4": "directional sign"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0715": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0715_o1": "no entering the intersection",
+        "q0715_o2": "no right turn",
+        "q0715_o3": "no changing lane",
+        "q0715_o4": "no U turn"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0716": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0716_o1": "no U turn at intersection",
+        "q0716_o2": "no changing lane from both sides",
+        "q0716_o3": "no left or right turn",
+        "q0716_o4": "no going straight"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0717": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0717_o1": "going straight and right turn",
+        "q0717_o2": "going straight and left turn",
+        "q0717_o3": "no going straight and no left turn",
+        "q0717_o4": "right turn and left turn only"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0718": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0718_o1": "passing by the right side",
+        "q0718_o2": "passing by the left side",
+        "q0718_o3": "running to right side",
+        "q0718_o4": "running the roundabout"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0719": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0719_o1": "left one-way road",
+        "q0719_o2": "right one-way road",
+        "q0719_o3": "straight one-way road",
+        "q0719_o4": "yield if going to turn right"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0720": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0720_o1": "special lane for large buses",
+        "q0720_o2": "special lane for public buses",
+        "q0720_o3": "special lane for Bus Rapid Transit System",
+        "q0720_o4": "special lane for multi-passenger vehicles"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0721": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0721_o1": "lane information indication",
+        "q0721_o2": "road branching point ahead",
+        "q0721_o3": "place and distance indication",
+        "q0721_o4": "intersection ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0722": {
+      "prompt": "What marking is the white polylines in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0722_o1": "ascertaining the distance between the vehicles",
+        "q0722_o2": "driving at reduced speed",
+        "q0722_o3": "ascertaining the speed of the vehicles",
+        "q0722_o4": "reducing the speed at the intersection"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0723": {
+      "prompt": "What marking is the combination of the white broken lines and the triangle area?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0723_o1": "road entry marking",
+        "q0723_o2": "lane-dividing line that can be crossed",
+        "q0723_o3": "deceleration line at road entry",
+        "q0723_o4": "road exit marking"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0724": {
+      "prompt": "What kind of marking are the double yellow solid lines in the middle of the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0724_o1": "auxiliary marking",
+        "q0724_o2": "warning sign",
+        "q0724_o3": "prohibitive marking",
+        "q0724_o4": "indicative marking"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0725": {
+      "prompt": "What’s the meaning of the yellow broken and solid lines in the middle of the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0725_o1": "no crossing the lines on the side of the broken line",
+        "q0725_o2": "no crossing the lines on the side of the solid line",
+        "q0725_o3": "allowed to cross the lines on the side of the solid line",
+        "q0725_o4": "allowed to cross the lines on both sides"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0726": {
+      "prompt": "What’s the meaning of the white solid line in the middle of the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0726_o1": "unilateral same direction lanes dividing line that can be crossed",
+        "q0726_o2": "same direction lanes dividing line that can not be crossed",
+        "q0726_o3": "bilateral same direction lanes dividing line that can be crossed",
+        "q0726_o4": "opposite direction lanes dividing line that can not be crossed"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0727": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ____ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0727_o1": "wait to turn left",
+        "q0727_o2": "pull over",
+        "q0727_o3": "turn left",
+        "q0727_o4": "turn right"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0728": {
+      "prompt": "How to run if this traffic light continuously flashes?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0728_o1": "speed up and pass as soon as possible",
+        "q0728_o2": "stop by the side to wait",
+        "q0728_o3": "look and make sure it is safe to pass",
+        "q0728_o4": "apply emergency braking"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0729": {
+      "prompt": "How to run when seeing this traffic light at level crossing?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0729_o1": "pass before the train comes",
+        "q0729_o2": "no exceeding the stop line",
+        "q0729_o3": "observe and pass slowly",
+        "q0729_o4": "speed up and pass without changing gear"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0730": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0730_o1": "sharp right curve",
+        "q0730_o2": "bypass from right side",
+        "q0730_o3": "continuous curves",
+        "q0730_o4": "sharp left curve"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0731": {
+      "prompt": "What is this traffic sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0731_o1": "Road narrows on both sides",
+        "q0731_o2": "Road narrows on the right side",
+        "q0731_o3": "Road narrows on the left side",
+        "q0731_o4": "Bridge narrows"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0732": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0732_o1": "school area",
+        "q0732_o2": "watch for children",
+        "q0732_o3": "crosswalk",
+        "q0732_o4": "watch for pedestrians"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0733": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0733_o1": "slippery section",
+        "q0733_o2": "sharp curve",
+        "q0733_o3": "test driving section",
+        "q0733_o4": "curve section"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0734": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0734_o1": "water channel",
+        "q0734_o2": "bridge",
+        "q0734_o3": "tunnel",
+        "q0734_o4": "Culvert"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0735": {
+      "prompt": "What’s the role of the prohibitive sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0735_o1": "indicate the vehicles to go ahead",
+        "q0735_o2": "warn danger ahead",
+        "q0735_o3": "prohibit or restrict from doing",
+        "q0735_o4": "tell the direction information"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0736": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0736_o1": "no right turn",
+        "q0736_o2": "no U turn",
+        "q0736_o3": "no going straight",
+        "q0736_o4": "no left turn"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0737": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0737_o1": "lanes for going in different directions",
+        "q0737_o2": "lane for both U turn and left turn",
+        "q0737_o3": "the lane of no left turn and no U turn",
+        "q0737_o4": "lane for both going straight and left turn"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0738": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0738_o1": "township road No.",
+        "q0738_o2": "county road No.",
+        "q0738_o3": "provincial highway No.",
+        "q0738_o4": "national highway No."
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0739": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0739_o1": "no left turn",
+        "q0739_o2": "dead-end road",
+        "q0739_o3": "no passing",
+        "q0739_o4": "bypass if over height"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0740": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0740_o1": "expressway emergency strip",
+        "q0740_o2": "expressway yielding area",
+        "q0740_o3": "expressway bus station",
+        "q0740_o4": "expressway parking area"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0741": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0741_o1": "distance to a tourist area",
+        "q0741_o2": "direction of a tourist area",
+        "q0741_o3": "symbol of a tourist area",
+        "q0741_o4": "category of a tourist area"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0742": {
+      "prompt": "What’s the meaning of this park marking?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0742_o1": "special stopping and waiting area",
+        "q0742_o2": "special getting-on and getting-off area",
+        "q0742_o3": "time limit parking",
+        "q0742_o4": "fixed direction parking"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0743": {
+      "prompt": "What’s the meaning of this guide arrow on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0743_o1": "left curve or need to bypass from left side ahead",
+        "q0743_o2": "merge with the left flow due to obstacle ahead",
+        "q0743_o3": "right curve or need to merge with the right flow ahead",
+        "q0743_o4": "left curve or need to merge with the left flow ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0744": {
+      "prompt": "What’s the meaning of this mark on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0744_o1": "minimum speed limit is 80km/hr",
+        "q0744_o2": "average speed is 80km/hr",
+        "q0744_o3": "maximum speed limit is 80km/hr",
+        "q0744_o4": "80km/hr speed limit ban is lifted"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0745": {
+      "prompt": "What’s the meaning of the yellow marking on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0745_o1": "gradual road width",
+        "q0745_o2": "more carriageways",
+        "q0745_o3": "closing to obstacle",
+        "q0745_o4": "construction section indication"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0746": {
+      "prompt": "The vehicle is allowed to _______ at this intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0746_o1": "go straight or turn right",
+        "q0746_o2": "turn left",
+        "q0746_o3": "go straight or turn left",
+        "q0746_o4": "turn left or turn right"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0747": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0747_o1": "steep downhill road",
+        "q0747_o2": "continuous up slopes",
+        "q0747_o3": "steep uphill road",
+        "q0747_o4": "embankment road"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0748": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0748_o1": "embankment road",
+        "q0748_o2": "steep uphill road",
+        "q0748_o3": "continuous up slopes",
+        "q0748_o4": "steep downhill road"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0749": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0749_o1": "exit and entry for disabled people",
+        "q0749_o2": "watch for disabled people",
+        "q0749_o3": "rest area for disabled people",
+        "q0749_o4": "special passage for disabled people"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0750": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0750_o1": "accident-prone section",
+        "q0750_o2": "construction section",
+        "q0750_o3": "reducing speed and going slowly section",
+        "q0750_o4": "jammed section"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0751": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0751_o1": "Y-shaped intersection",
+        "q0751_o2": "main road yield",
+        "q0751_o3": "attention to branching",
+        "q0751_o4": "attention to merging"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0752": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0752_o1": "reducing speed 40m ahead",
+        "q0752_o2": "minimum speed is 40km/hr",
+        "q0752_o3": "axle weight limit is 40 tons",
+        "q0752_o4": "maximum speed limit is 40km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0753": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0753_o1": "downhill section on right side",
+        "q0753_o2": "driving by the right side of the road",
+        "q0753_o3": "stopping by the right side of the road",
+        "q0753_o4": "right turn only"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0754": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0754_o1": "going straight and turning left at an interchange",
+        "q0754_o2": "going straight and turning right at an interchange",
+        "q0754_o3": "going straight and turning left",
+        "q0754_o4": "going straight and turning right"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0755": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0755_o1": "right-turn lane",
+        "q0755_o2": "U turn lane",
+        "q0755_o3": "left-turn lane",
+        "q0755_o4": "lanes for going in different directions"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0756": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0756_o1": "U turn",
+        "q0756_o2": "reversing",
+        "q0756_o3": "left turn",
+        "q0756_o4": "bypassing"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0757": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0757_o1": "lane direction indication",
+        "q0757_o2": "intersection ahead",
+        "q0757_o3": "lane information indication",
+        "q0757_o4": "road branching point ahead"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0758": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0758_o1": "location and distance",
+        "q0758_o2": "driving route",
+        "q0758_o3": "destination name",
+        "q0758_o4": "driving direction"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0759": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0759_o1": "expressway right side exit ahead",
+        "q0759_o2": "expressway next exit indication",
+        "q0759_o3": "expressway location and direction indication",
+        "q0759_o4": "expressway left side exit ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0760": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0760_o1": "expressway mileage No.",
+        "q0760_o2": "expressway border plate No.",
+        "q0760_o3": "expressway name No.",
+        "q0760_o4": "expressway section No."
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0761": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0761_o1": "expressway public phone",
+        "q0761_o2": "expressway police phone",
+        "q0761_o3": "expressway emergency phone",
+        "q0761_o4": "expressway rescue phone"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0762": {
+      "prompt": "What marking is the triagle filled area in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0762_o1": "stop line",
+        "q0762_o2": "deceleration line",
+        "q0762_o3": "guide line",
+        "q0762_o4": "cross-hatched marking"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0763": {
+      "prompt": "The vehicle is allowed to _______ at this intersection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0763_o1": "go straight or turn right",
+        "q0763_o2": "turn right",
+        "q0763_o3": "turn left",
+        "q0763_o4": "go straight"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0764": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0764_o1": "intersection",
+        "q0764_o2": "ring intersection",
+        "q0764_o3": "T-shaped intersection",
+        "q0764_o4": "Y-shaped intersection"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0765": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0765_o1": "crosswalk lights",
+        "q0765_o2": "watch for pedestrians",
+        "q0765_o3": "attention to traffic lights",
+        "q0765_o4": "intersection"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0766": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0766_o1": "low-lying road",
+        "q0766_o2": "hump bridge",
+        "q0766_o3": "bump road",
+        "q0766_o4": "high outburst road"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0767": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0767_o1": "reduce speed and go slowly",
+        "q0767_o2": "watch for danger",
+        "q0767_o3": "jammed section",
+        "q0767_o4": "accident-prone section"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0768": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0768_o1": "going straight and left turn",
+        "q0768_o2": "going straight and right turn",
+        "q0768_o3": "no going straight and no right turn",
+        "q0768_o4": "left turn and right turn only"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0769": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0769_o1": "streets on both sides",
+        "q0769_o2": "main road go first",
+        "q0769_o3": "stop to yield",
+        "q0769_o4": "one-way road"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0770": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0770_o1": "U turn lane",
+        "q0770_o2": "bypassing lane",
+        "q0770_o3": "lanes for going in different directions",
+        "q0770_o4": "left-turn lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0771": {
+      "prompt": "What kind of sign is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0771_o1": "directional sign",
+        "q0771_o2": "indicative sign",
+        "q0771_o3": "prohibitive sign",
+        "q0771_o4": "warning sign"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0772": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0772_o1": "expressway toll station",
+        "q0772_o2": "expressway checkpoint",
+        "q0772_o3": "toll station with ETC",
+        "q0772_o4": "expressway card-getting point"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0773": {
+      "prompt": "What marking is the white broken line on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0773_o1": "central line of opposite lanes which is prohibited from crossing",
+        "q0773_o2": "central line of opposite lanes which is restricted from crossing",
+        "q0773_o3": "central dividing line of the one-way road lanes",
+        "q0773_o4": "central line of same direction lanes which is allowed to cross"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0774": {
+      "prompt": "What’s the meaning of the white broken line by the carriage on the right side road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0774_o1": "allowed to temporarily cross",
+        "q0774_o2": "prohibited from crossing",
+        "q0774_o3": "emergency lanes dividing line",
+        "q0774_o4": "crosswalk dividing line"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0775": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0775_o1": "no passing",
+        "q0775_o2": "driving lane",
+        "q0775_o3": "merging",
+        "q0775_o4": "going straight"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0776": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0776_o1": "changing to left lane",
+        "q0776_o2": "going straight ahead",
+        "q0776_o3": "left turn ahead",
+        "q0776_o4": "right turn ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0777": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0777_o1": "going straight and U turn are allowed ahead",
+        "q0777_o2": "left turn and U turn are allowed ahead",
+        "q0777_o3": "going straight and changing to left lane are allowed ahead",
+        "q0777_o4": "going straight and left turn are allowed ahead"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0778": {
+      "prompt": "What’s the meaning of the white markings on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0778_o1": "road construction marking",
+        "q0778_o2": "horizontal deceleration marking",
+        "q0778_o3": "vertical deceleration marking",
+        "q0778_o4": "fewer lanes indication marking"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0779": {
+      "prompt": "What’s the meaning of the yellow filled markings on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0779_o1": "closing to the obstacle",
+        "q0779_o2": "closing narrowed road",
+        "q0779_o3": "closing the moving obstacle",
+        "q0779_o4": "Marking of approaching a narrow road"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0780": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0780_o1": "road narrows on the left side",
+        "q0780_o2": "narrow bridge",
+        "q0780_o3": "narrow road",
+        "q0780_o4": "road narrows on the right side"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0781": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0781_o1": "watch for animals",
+        "q0781_o2": "watch for wildlife",
+        "q0781_o3": "Wildlife Sanctuary",
+        "q0781_o4": "Large-scale farms"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0782": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0782_o1": "bump road",
+        "q0782_o2": "high outburst road",
+        "q0782_o3": "low-lying road",
+        "q0782_o4": "hump bridge"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0783": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0783_o1": "an unmanned level crossing 150m ahead",
+        "q0783_o2": "an unmanned level crossing 100m ahead",
+        "q0783_o3": "a manned level crossing 100m ahead",
+        "q0783_o4": "a manned level crossing 150m ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0784": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0784_o1": "bypass at construction section",
+        "q0784_o2": "two-way traffic",
+        "q0784_o3": "bypass from left or right side",
+        "q0784_o4": "watch for danger"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0785": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0785_o1": "bypass from right side",
+        "q0785_o2": "one-way passing",
+        "q0785_o3": "watch for danger",
+        "q0785_o4": "bypass from left side"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0786": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0786_o1": "stop and yield the right side vehicle while crossing each other",
+        "q0786_o2": "no passing on the right side road",
+        "q0786_o3": "two-way lane section ahead",
+        "q0786_o4": "stop and yield the opposite vehicle while crossing each other"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0787": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0787_o1": "No passing",
+        "q0787_o2": "driving at reduced speed",
+        "q0787_o3": "time limit for entering",
+        "q0787_o4": "no entering"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0788": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0788_o1": "no stopping temporarily",
+        "q0788_o2": "no long stopping",
+        "q0788_o3": "no stopping",
+        "q0788_o4": "long stopping is allowed"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0789": {
+      "prompt": "Which kind of sign is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0789_o1": "warning sign",
+        "q0789_o2": "prohibitive sign",
+        "q0789_o3": "indicative sign",
+        "q0789_o4": "directional sign"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0790": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0790_o1": "no left turn",
+        "q0790_o2": "left and right turn",
+        "q0790_o3": "no left and right turn",
+        "q0790_o4": "no right turn"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0791": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0791_o1": "right-turn lane",
+        "q0791_o2": "U turn lane",
+        "q0791_o3": "left-turn lane",
+        "q0791_o4": "lanes for going in different directions"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0792": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0792_o1": "no passing for small vehicle",
+        "q0792_o2": "passing for small vehicle only",
+        "q0792_o3": "passing for motorized vehicle",
+        "q0792_o4": "no passing for small vehicle"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0793": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0793_o1": "special lane for small vehicles",
+        "q0793_o2": "special lane for motorized vehicles",
+        "q0793_o3": "special lane for taxis",
+        "q0793_o4": "special lane for multi-passenger vehicles"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0794": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0794_o1": "special car park",
+        "q0794_o2": "uncovered car park",
+        "q0794_o3": "indoor car park",
+        "q0794_o4": "internal car park"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0795": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0795_o1": "fewer lanes",
+        "q0795_o2": "merging point",
+        "q0795_o3": "emergency lane",
+        "q0795_o4": "changing to left lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0796": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0796_o1": "line guide signs",
+        "q0796_o2": "lane merging guide signs",
+        "q0796_o3": "lane branching guide signs",
+        "q0796_o4": "turning guide signs"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0797": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0797_o1": "Passing on both sides",
+        "q0797_o2": "Passing by the right side",
+        "q0797_o3": "Passing by the left side",
+        "q0797_o4": "Passing is prohibited"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0798": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0798_o1": "expressway entry ahead",
+        "q0798_o2": "expressway ending ahead",
+        "q0798_o3": "expressway beginning ahead",
+        "q0798_o4": "expressway exit ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0799": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0799_o1": "expressway exit",
+        "q0799_o2": "expressway beginning",
+        "q0799_o3": "expressway entry",
+        "q0799_o4": "expressway ending"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0800": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0800_o1": "stop to get card",
+        "q0800_o2": "stop to pay",
+        "q0800_o3": "ETC lane",
+        "q0800_o4": "stop for inspection"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0801": {
+      "prompt": "What kind of marking is the yellow broken line in the center of the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0801_o1": "indicative marking",
+        "q0801_o2": "prohibitive marking",
+        "q0801_o3": "warning sign",
+        "q0801_o4": "auxiliary marking"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0802": {
+      "prompt": "What marking is the combination of the white broken lines and the triangle area?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0802_o1": "road entry marking",
+        "q0802_o2": "lane-dividing line that can be crossed",
+        "q0802_o3": "deceleration line at road exit",
+        "q0802_o4": "road exit marking"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0803": {
+      "prompt": "What marking is it?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0803_o1": "A cross-hatched marking",
+        "q0803_o2": "prohibitive area",
+        "q0803_o3": "guide line",
+        "q0803_o4": "central circle"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0804": {
+      "prompt": "What marking is the yellow road surface in the center of the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0804_o1": "central circle",
+        "q0804_o2": "guide line",
+        "q0804_o3": "cross-hatched marking",
+        "q0804_o4": "parking area"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0805": {
+      "prompt": "What’s the meaning of the yellow mark on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0805_o1": "no going straight",
+        "q0805_o2": "allowed to make a U turn",
+        "q0805_o3": "no U turn",
+        "q0805_o4": "no making a turn"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0806": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ___ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0806_o1": "wait to turn left",
+        "q0806_o2": "pull over",
+        "q0806_o3": "turn right",
+        "q0806_o4": "reduce speed and pass slowly"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0807": {
+      "prompt": "What does the traffic light mean?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0807_o1": "no right turn",
+        "q0807_o2": "intersection warning",
+        "q0807_o3": "going straight is allowed",
+        "q0807_o4": "speed up and pass"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0808": {
+      "prompt": "What is this traffic sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0808_o1": "slippery section",
+        "q0808_o2": "sharp curve",
+        "q0808_o3": "inverse curve",
+        "q0808_o4": "continuous curves"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0809": {
+      "prompt": "What is this traffic sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0809_o1": "slippery section",
+        "q0809_o2": "sharp curve",
+        "q0809_o3": "inverse curve",
+        "q0809_o4": "continuous curves"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0810": {
+      "prompt": "What is this traffic sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0810_o1": "Road narrows on both sides",
+        "q0810_o2": "Road narrows on the right side",
+        "q0810_o3": "Road narrows on the left side",
+        "q0810_o4": "Bridge narrows"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0811": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0811_o1": "dangerous hillside road",
+        "q0811_o2": "cliff section",
+        "q0811_o3": "watch for dropping stone",
+        "q0811_o4": "dangerous section"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0812": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0812_o1": "a manned level crossing 50m ahead",
+        "q0812_o2": "an unmanned level crossing 100m ahead",
+        "q0812_o3": "a manned level crossing 100m ahead",
+        "q0812_o4": "an unmanned level crossing 50m ahead"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0813": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0813_o1": "more vehicles section",
+        "q0813_o2": "passing slowly",
+        "q0813_o3": "jammed section",
+        "q0813_o4": "construction section"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0814": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0814_o1": "reduce speed in tunnel",
+        "q0814_o2": "turn on the high beam lights in tunnel",
+        "q0814_o3": "turn on the light in tunnel",
+        "q0814_o4": "width light in tunnel"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0815": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0815_o1": "danger-avoiding lane",
+        "q0815_o2": "emergency lane",
+        "q0815_o3": "road shoulder",
+        "q0815_o4": "sharp curve"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0816": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0816_o1": "no yielding",
+        "q0816_o2": "yield while crossing each other",
+        "q0816_o3": "reduce speed and yield",
+        "q0816_o4": "stop to yield"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0817": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0817_o1": "yield if going to turn left",
+        "q0817_o2": "straight one-way road",
+        "q0817_o3": "right one-way road",
+        "q0817_o4": "left one-way road"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0818": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0818_o1": "running by right side",
+        "q0818_o2": "no going straight",
+        "q0818_o3": "straight one-way road",
+        "q0818_o4": "yield if going to go straight"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0819": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0819_o1": "special lane for large buses",
+        "q0819_o2": "special lane for multi-passenger vehicles",
+        "q0819_o3": "special lane for public buses",
+        "q0819_o4": "special lane for BRT vehicles"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0820": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0820_o1": "ring intersection ahead",
+        "q0820_o2": "intersection ahead",
+        "q0820_o3": "Y-shaped intersection ahead",
+        "q0820_o4": "T-shaped intersection ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0821": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0821_o1": "intersection ahead",
+        "q0821_o2": "interchange ahead",
+        "q0821_o3": "Y-shaped intersection ahead",
+        "q0821_o4": "ring intersection ahead"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0822": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0822_o1": "T-shaped intersection",
+        "q0822_o2": "branching intersection",
+        "q0822_o3": "reduce speed to pass",
+        "q0822_o4": "dead-end road"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0823": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0823_o1": "change to right lane",
+        "q0823_o2": "branching point",
+        "q0823_o3": "road surface becomes wider",
+        "q0823_o4": "the number of lanes increases"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0824": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0824_o1": "expressway next exit ahead",
+        "q0824_o2": "expressway right exit ahead",
+        "q0824_o3": "expressway left exit ahead",
+        "q0824_o4": "expressway destination indication"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0825": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0825_o1": "distance to a tourist area",
+        "q0825_o2": "category of a tourist area",
+        "q0825_o3": "direction of a tourist area",
+        "q0825_o4": "symbol of a tourist area"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0826": {
+      "prompt": "What marking is the white solid lines in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0826_o1": "guide lanes lines",
+        "q0826_o2": "variable guide lanes lines",
+        "q0826_o3": "direction guide lines",
+        "q0826_o4": "one-way driving lines"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0827": {
+      "prompt": "What marking is the road mark in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0827_o1": "crosswalk line",
+        "q0827_o2": "slowdown and yield line",
+        "q0827_o3": "stopping and yield line",
+        "q0827_o4": "intersection signal line"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0828": {
+      "prompt": "What marking is the road mark?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0828_o1": "crosswalk ahead",
+        "q0828_o2": "intersection ahead",
+        "q0828_o3": "reduce speed and yield ahead",
+        "q0828_o4": "stop to yield ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0829": {
+      "prompt": "What’s the meaning of the marking in the red circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0829_o1": "temporary stopping",
+        "q0829_o2": "bay-stopping",
+        "q0829_o3": "emergency stopping",
+        "q0829_o4": "public bus station"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0830": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0830_o1": "left curve or need to merge with the left flow ahead",
+        "q0830_o2": "right curve or need to merge with the right flow ahead",
+        "q0830_o3": "merge with the left flow due to right side obstacle ahead",
+        "q0830_o4": "left curve or need to bypass from left side ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0831": {
+      "prompt": "What’s the meaning of the yellow broken line on curbstone?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0831_o1": "no temporary stopping",
+        "q0831_o2": "no taking and dropping people",
+        "q0831_o3": "no loading and unloading cargos",
+        "q0831_o4": "no long stopping"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0832": {
+      "prompt": "What’s the meaning of the white horizontal solid line in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0832_o1": "turning waiting line",
+        "q0832_o2": "deceleration line",
+        "q0832_o3": "yielding line",
+        "q0832_o4": "stop line"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0833": {
+      "prompt": "What’s the meaning of the double white broken lines in far front of the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0833_o1": "waiting to run line",
+        "q0833_o2": "stopping and yield line",
+        "q0833_o3": "slowdown and yield line",
+        "q0833_o4": "left-turn waiting line"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0834": {
+      "prompt": "What’s the meaning of the diamond broken lines on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0834_o1": "road construction marking",
+        "q0834_o2": "vertical deceleration marking",
+        "q0834_o3": "horizontal deceleration marking",
+        "q0834_o4": "fewer lanes indication marking"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0835": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0835_o1": "tunnel entry",
+        "q0835_o2": "observatory",
+        "q0835_o3": "mind side wind",
+        "q0835_o4": "wind vane"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0836": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0836_o1": "embankment road",
+        "q0836_o2": "cliffside road",
+        "q0836_o3": "waterside road",
+        "q0836_o4": "slippery road"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0837": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0837_o1": "a manned level crossing",
+        "q0837_o2": "an unmanned level crossing",
+        "q0837_o3": "multi-crossing of railway and road",
+        "q0837_o4": "yielding the train with care"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0838": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0838_o1": "the lane for non-motorized vehicles",
+        "q0838_o2": "yield non-motorized vehicles",
+        "q0838_o3": "no passing for non-motorized vehicles",
+        "q0838_o4": "watch for non-motorized vehicles"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0839": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0839_o1": "no borrowing lane",
+        "q0839_o2": "no changing lane",
+        "q0839_o3": "no overtaking",
+        "q0839_o4": "no U turn"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0840": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0840_o1": "stopping temporarily is allowed",
+        "q0840_o2": "long stopping is allowed",
+        "q0840_o3": "no long stopping",
+        "q0840_o4": "no stopping"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0841": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0841_o1": "3.5m width limit",
+        "q0841_o2": "3.5m width limit ban is lifted",
+        "q0841_o3": "3.5m distance from vehicles limit",
+        "q0841_o4": "3.5m height limit"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0842": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0842_o1": "driving at reduced speed in the section of 40 meters",
+        "q0842_o2": "minimum speed is 40km/hr",
+        "q0842_o3": "maximum speed is 40km/hr",
+        "q0842_o4": "40km/hr speed limit ban is lifted"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0843": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0843_o1": "stop by the left side of the road",
+        "q0843_o2": "downhill section left",
+        "q0843_o3": "left turn only",
+        "q0843_o4": "run by the left side of the road"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0844": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0844_o1": "going straight and turning left",
+        "q0844_o2": "going straight and turning right",
+        "q0844_o3": "going straight and turning right at an interchange",
+        "q0844_o4": "going straight and turning left at an interchange"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0845": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0845_o1": "electric bicycles may go",
+        "q0845_o2": "parking space for non-motorized vehicles",
+        "q0845_o3": "parking area for non-motorized vehicles",
+        "q0845_o4": "non-motorized vehicles may go"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0846": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0846_o1": "T-shaped intersection ahead",
+        "q0846_o2": "road branching point ahead",
+        "q0846_o3": "Y-shaped intersection ahead",
+        "q0846_o4": "intersection ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0847": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0847_o1": "rescue call number on expressway",
+        "q0847_o2": "service call number on expressway",
+        "q0847_o3": "police call number on expressway",
+        "q0847_o4": "traffic radio frequency on expressway"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0848": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0848_o1": "change to left lane",
+        "q0848_o2": "going straight ahead",
+        "q0848_o3": "U turn ahead",
+        "q0848_o4": "right turn ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0849": {
+      "prompt": "How to go straight when encountering this traffic light at the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0849_o1": "enter the intersection to wait",
+        "q0849_o2": "turn left",
+        "q0849_o3": "speed up and pass straight",
+        "q0849_o4": "can not exceed the stop line"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0850": {
+      "prompt": "How to run when encountering this situation?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0850_o1": "speed up to enter the lane of either side",
+        "q0850_o2": "enter the right lane",
+        "q0850_o3": "reduce speed and enter the lane of either side",
+        "q0850_o4": "can not run in the lane of neither side"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0851": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0851_o1": "overflowing bridge",
+        "q0851_o2": "ferry",
+        "q0851_o3": "pier",
+        "q0851_o4": "overflowing road"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0852": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0852_o1": "watch for two-way road",
+        "q0852_o2": "driving by either side of the road",
+        "q0852_o3": "watch for variable lane",
+        "q0852_o4": "variable lane"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0853": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0853_o1": "flat intersection",
+        "q0853_o2": "flat ring intersection",
+        "q0853_o3": "attention to interactive intersection",
+        "q0853_o4": "attention to separate intersection"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0854": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0854_o1": "stop to yield",
+        "q0854_o2": "no stopping temporarily",
+        "q0854_o3": "no entry",
+        "q0854_o4": "no long stopping"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0855": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0855_o1": "straight-going lane",
+        "q0855_o2": "going straight only",
+        "q0855_o3": "one-way road",
+        "q0855_o4": "no going straight"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0856": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0856_o1": "internal car park",
+        "q0856_o2": "special car park",
+        "q0856_o3": "uncovered car park",
+        "q0856_o4": "indoor car park"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0857": {
+      "prompt": "What markings are the two double yellow broken lines on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0857_o1": "two-way lanes dividing line",
+        "q0857_o2": "variable lane line",
+        "q0857_o3": "lane-dividing line that can be crossed",
+        "q0857_o4": "one-way lanes dividing line"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0858": {
+      "prompt": "What marking is the yellow broken line in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0858_o1": "non-motorized vehicles guide lines",
+        "q0858_o2": "intersection guide line",
+        "q0858_o3": "lane connection lines",
+        "q0858_o4": "small vehicles turning lines"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0859": {
+      "prompt": "What marking are the white serrated solid lines in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0859_o1": "guide lane lines",
+        "q0859_o2": "direction guide line",
+        "q0859_o3": "variable guide lane line",
+        "q0859_o4": "one-way driving line"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0860": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0860_o1": "going straight or U turn",
+        "q0860_o2": "going straight or left turn",
+        "q0860_o3": "going straight or changing to left lane",
+        "q0860_o4": "left turn or U turn"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0861": {
+      "prompt": "What’s the meaning of this guide arrow?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0861_o1": "Y-shaped intersection ahead",
+        "q0861_o2": "separate road ahead",
+        "q0861_o3": "only left or right turn ahead",
+        "q0861_o4": "merging with both sides ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0862": {
+      "prompt": "What’s the meaning of this mark on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0862_o1": "average speed is 100km/hr",
+        "q0862_o2": "minimum speed limit is 100km/hr",
+        "q0862_o3": "100km/hr speed limit ban is lifted",
+        "q0862_o4": "maximum speed limit is 100km/hr"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0863": {
+      "prompt": "What’s the meaning of this mark on the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0863_o1": "the lane for non-motorized vehicles",
+        "q0863_o2": "the special lane for motorcycles",
+        "q0863_o3": "the special lane for battery bicycles",
+        "q0863_o4": "the special lane for bicycles"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0864": {
+      "prompt": "What’s the meaning of the double yellow solid lines?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0864_o1": "opposite direction lanes dividing line that can not be crossed",
+        "q0864_o2": "opposite direction lanes dividing line that can be crossed",
+        "q0864_o3": "bilateral same direction lanes dividing line that can be crossed",
+        "q0864_o4": "one-way lanes dividing line"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0865": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0865_o1": "embankment road",
+        "q0865_o2": "dangerous hillside road",
+        "q0865_o3": "rock-falling road",
+        "q0865_o4": "cliffside road"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0866": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0866_o1": "watch for danger",
+        "q0866_o2": "bypass from right side",
+        "q0866_o3": "bypass from left side",
+        "q0866_o4": "one-way pass"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0867": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0867_o1": "no going straight and no changing to left lane",
+        "q0867_o2": "no going straight and no left turn",
+        "q0867_o3": "allowed to go straight and change to left lane",
+        "q0867_o4": "no going straight and no right turn"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0868": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0868_o1": "turn right",
+        "q0868_o2": "one-way road",
+        "q0868_o3": "going straight only",
+        "q0868_o4": "straight-going lane"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0869": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0869_o1": "straight-going and left-turn lane",
+        "q0869_o2": "straight-going and side road exit lane",
+        "q0869_o3": "lane for both going straight and right turn",
+        "q0869_o4": "lanes for going in different directions"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0870": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0870_o1": "lane for both going straight and U turn",
+        "q0870_o2": "lane for both going straight and left turn",
+        "q0870_o3": "lane for going straight and right turn",
+        "q0870_o4": "lanes for going in different directions"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0871": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0871_o1": "no entry for bicycles",
+        "q0871_o2": "lane for non-motorized vehicles",
+        "q0871_o3": "special lane for bicycles",
+        "q0871_o4": "bicycle stopping area"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0872": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0872_o1": "Passing on both sides",
+        "q0872_o2": "Passing is prohibited",
+        "q0872_o3": "Passing by the left side",
+        "q0872_o4": "Passing by the right side"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0873": {
+      "prompt": "What’s the meaning of the yellow slash filled area in the middle of the road?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0873_o1": "one-way lanes dividing line",
+        "q0873_o2": "opposite direction lanes dividing line that can not be crossed",
+        "q0873_o3": "bilateral same direction lanes dividing line that can be crossed",
+        "q0873_o4": "opposite direction lanes dividing line that can be crossed"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0874": {
+      "prompt": "What’s the meaning of the double white solid lines in far front of the intersection?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0874_o1": "stopping and yield line",
+        "q0874_o2": "slowdown and yield line",
+        "q0874_o3": "left-turn waiting line",
+        "q0874_o4": "waiting to run line"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0875": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ___ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0875_o1": "turn left",
+        "q0875_o2": "wait to turn left",
+        "q0875_o3": "reduce speed and pass slowly",
+        "q0875_o4": "turn right"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0876": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0876_o1": "max speed",
+        "q0876_o2": "speed limit",
+        "q0876_o3": "speed recommended",
+        "q0876_o4": "mini speed"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0877": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0877_o1": "stop to yield",
+        "q0877_o2": "one-way road",
+        "q0877_o3": "going first when crossing each other",
+        "q0877_o4": "the opposite vehicle goes first when crossing each other"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0878": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0878_o1": "right-turn lane",
+        "q0878_o2": "U turn lane",
+        "q0878_o3": "left-turn lane",
+        "q0878_o4": "straight-going lane"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0879": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0879_o1": "uncovered car park",
+        "q0879_o2": "emergency stopping",
+        "q0879_o3": "parking space",
+        "q0879_o4": "passing bay"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0880": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ___ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0880_o1": "wait to turn left",
+        "q0880_o2": "pull over",
+        "q0880_o3": "reduce speed and pass slowly",
+        "q0880_o4": "turn left"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0881": {
+      "prompt": "Whitch kind of vehicle is prohibited from passing by this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0881_o1": "all kinds",
+        "q0881_o2": "small bus",
+        "q0881_o3": "midsize bus",
+        "q0881_o4": "small truck"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0882": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0882_o1": "provincial highway No.",
+        "q0882_o2": "national highway No.",
+        "q0882_o3": "county road No.",
+        "q0882_o4": "township road No."
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0883": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0883_o1": "expressway right exit ahead",
+        "q0883_o2": "expressway destination indication",
+        "q0883_o3": "expressway left exit ahead",
+        "q0883_o4": "expressway next exit ahead"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0884": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0884_o1": "expressway bus station ahead",
+        "q0884_o2": "expressway shelter ahead",
+        "q0884_o3": "expressway service area ahead",
+        "q0884_o4": "expressway toll station ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0885": {
+      "prompt": "What’s the role of the indicative marking?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0885_o1": "No passing",
+        "q0885_o2": "indicate vehicles to pass",
+        "q0885_o3": "restrict from passing",
+        "q0885_o4": "warn and remind"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0886": {
+      "prompt": "What’s the meaning of the area between two yellow broken lines in the circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0886_o1": "special lane for operating buses",
+        "q0886_o2": "special lane for large buses",
+        "q0886_o3": "special lane for taxis",
+        "q0886_o4": "special lane for public buses"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0887": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ___ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0887_o1": "go straight",
+        "q0887_o2": "make a turn",
+        "q0887_o3": "stop",
+        "q0887_o4": "pull over"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0888": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0888_o1": "landslide section",
+        "q0888_o2": "construction section",
+        "q0888_o3": "factory ahead",
+        "q0888_o4": "jammed road"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0889": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0889_o1": "no long time honking",
+        "q0889_o2": "honk discontinuously",
+        "q0889_o3": "reduce speed and honk",
+        "q0889_o4": "no honking"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0890": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0890_o1": "pass with low speed",
+        "q0890_o2": "watch for pedestrians",
+        "q0890_o3": "on foot",
+        "q0890_o4": "pedestrians go first"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0891": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0891_o1": "minimum speed limit is 50km/hr",
+        "q0891_o2": "maximum speed limit is 50km/hr",
+        "q0891_o3": "the height is 50m",
+        "q0891_o4": "the altitude is 50m"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0892": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0892_o1": "rest area",
+        "q0892_o2": "service area",
+        "q0892_o3": "car park",
+        "q0892_o4": "observation deck"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0893": {
+      "prompt": "What’s the meaning of the marking in the red circle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0893_o1": "temporary stopping",
+        "q0893_o2": "large bus stopping",
+        "q0893_o3": "bus station",
+        "q0893_o4": "emergency stopping"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0894": {
+      "prompt": "What mark is the inclined yellow and black lines?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0894_o1": "entity mark",
+        "q0894_o2": "protrusions mark",
+        "q0894_o3": "three-dimensional mark",
+        "q0894_o4": "deceleration mark"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0895": {
+      "prompt": "This sign indicates ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0895_o1": "expressway service area ahead",
+        "q0895_o2": "expressway shelter ahead",
+        "q0895_o3": "expressway bus station ahead",
+        "q0895_o4": "expressway parking area ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0896": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ___ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0896_o1": "turn right",
+        "q0896_o2": "reduce speed and pass slowly",
+        "q0896_o3": "pull over",
+        "q0896_o4": "change lane"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0897": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0897_o1": "a manned level crossing",
+        "q0897_o2": "multi-crossing of railway and road",
+        "q0897_o3": "grade separation level crossing",
+        "q0897_o4": "an unmanned level crossing"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0898": {
+      "prompt": "What’s the meaning of this sign?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0898_o1": "watch for long time honking",
+        "q0898_o2": "an unmanned level crossing",
+        "q0898_o3": "a manned level crossing",
+        "q0898_o4": "multi-crossing of railway and road"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0899": {
+      "prompt": "This set of the hand signals of the traffic police indicates that the vehicles should ___ .",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0899_o1": "turn right",
+        "q0899_o2": "pull over",
+        "q0899_o3": "turn left",
+        "q0899_o4": "stop"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0900": {
+      "prompt": "The validity of the driving license which is initially applied for is ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0900_o1": "3 years",
+        "q0900_o2": "5 years",
+        "q0900_o3": "6 years",
+        "q0900_o4": "12 years"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0901": {
+      "prompt": "Which kind of vehicle can be driven if the authorized vehicle applied for is small motor vehicle?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0901_o1": "low-speed truck",
+        "q0901_o2": "midsize bus",
+        "q0901_o3": "motor tricycle",
+        "q0901_o4": "self-propelled wheeled machinery"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0902": {
+      "prompt": "Which kind of vehicle can be driven if the authorized vehicle applied for is small motor vehicle with automatic transmission?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0902_o1": "low-speed truck",
+        "q0902_o2": "small motor vehicle",
+        "q0902_o3": "motorcycle",
+        "q0902_o4": "light truck with automatic transmission"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0903": {
+      "prompt": "The driving license of 10-year validity will be issued if the penalty points never reached 12 points in every scoring cycle during the 6-year validity of the license.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0904": {
+      "prompt": "The validity of the driving license is divided into 6-year, 10-year and 20-year.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0905": {
+      "prompt": "One can drive the small motor vehicle with automatic transmission if the authorized vehicle applied for is small motor vehicle.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0907": {
+      "prompt": "The validity of the driving license which is initially applied for is 6 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0908": {
+      "prompt": "The validity of the driving license which is initially applied for is 4 years.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0909": {
+      "prompt": "Which kind of vehicle can be applied for when initially applying for the driving license?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0909_o1": "midsize bus",
+        "q0909_o2": "large bus",
+        "q0909_o3": "ordinary motor tricycle",
+        "q0909_o4": "trailer"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0910": {
+      "prompt": "Which kind of vehicle can be initially applied for when one reaches 20 years old?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0910_o1": "large truck",
+        "q0910_o2": "large bus",
+        "q0910_o3": "midsize bus",
+        "q0910_o4": "trailer"
+      },
+      "localeCorrectOptionKey": "A"
+    },
+    "q0911": {
+      "prompt": "The contents of subject 2 test for small motor vehicle include reversing stall parking, stopping at the appointed position and setting off on a slope, pulling over, driving by S-shaped line, sharp turning.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0912": {
+      "prompt": "The subject 3 test is divided into two parts including Driving Skills, Common Knowledge on Safe and Courteous Driving.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0913": {
+      "prompt": "The full mark of Driving Skills, Common Knowledge on Safe and Courteous Driving of the subject 3 test is 100, each of the passing mark is 80 and 90.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0914": {
+      "prompt": "Within the validity of the Admission Form, the times of test reservation for Driving Skills of subject 2 and subject 3 can not exceed ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0914_o1": "3 times",
+        "q0914_o2": "4 times",
+        "q0914_o3": "5 times",
+        "q0914_o4": "6 times"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0915": {
+      "prompt": "The validity of the Admission Form is _________",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0915_o1": "1 year",
+        "q0915_o2": "2 years",
+        "q0915_o3": "3 years",
+        "q0915_o4": "4 years"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0916": {
+      "prompt": "The applicant should apply for the cancelation of the reservation one day in advance if he is unable to take the exam by appointment, the applicant will be judged as failed in the exam if he does not take the exam on the reserved examination time.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0917": {
+      "prompt": "When a motorized vehicle driving license is lost or destroyed to be unrecognizable, the driver should apply to the issuing vehicle management station for a reissue.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0918": {
+      "prompt": "The driving license will not be revoked if the person drives after drug taking and injection.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0919": {
+      "prompt": "The driving license will be revoked when the person is executed community drug treatment, forced isolation treatment or community-based rehabilitation measures.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0920": {
+      "prompt": "If the registration paper, license plate and vehicle license of a motorized vehicle are lost or destroyed, the vehicle owner should apply for reissuing or replacing them to the _______________.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0920_o1": "traffic police detachment vehicle management station at the residential place",
+        "q0920_o2": "vehicle management station at the issuing place of the driving license",
+        "q0920_o3": "vehicle management station at the registration place",
+        "q0920_o4": "local police station"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0921": {
+      "prompt": "If the registration paper, license plate and vehicle license of a motorized vehicle are lost or destroyed, the vehicle owner should apply for reissuing or replacing them to the vehicle management station at the residential place.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0922": {
+      "prompt": "An unregistered motorized vehicle should have _________ if it has to run on the road temporarily.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0922_o1": "certificate of legal origin",
+        "q0922_o2": "license plate for temporary moving",
+        "q0922_o3": "borrowed license plate",
+        "q0922_o4": "certificate of legal unit"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0923": {
+      "prompt": "If a driving license has been revoked as it is obtained by deception, bribery or other illegal means, the applicant is not allowed to re-apply for it within ______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0923_o1": "6 months",
+        "q0923_o2": "1 year",
+        "q0923_o3": "2 years",
+        "q0923_o4": "3 years"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0924": {
+      "prompt": "If the applicant commits bribery or cheating in the course of a test, his eligibility for this test will be cancelled and the results of other tests he has passed will be invalid.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0925": {
+      "prompt": "Driving across the double solid lines is _______",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0925_o1": "rule-breaking act",
+        "q0925_o2": "violation of law",
+        "q0925_o3": "faulty act",
+        "q0925_o4": "violation of regulations"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0926": {
+      "prompt": "Stopping the vehicle temporarily in the crosswalk is the act of violation of the law.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0927": {
+      "prompt": "What does this sign mean?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0927_o1": "Reminding the side of a reservoir, lake or river ahead",
+        "q0927_o2": "Reminding the steep uphill road ahead",
+        "q0927_o3": "Reminding continuous two or more up slopes ahead",
+        "q0927_o4": "Reminding the steep downhill road ahead"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0928": {
+      "prompt": "What does this sign mean?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0928_o1": "Reminding the side of a reservoir, lake or river ahead",
+        "q0928_o2": "Reminding the steep uphill road ahead",
+        "q0928_o3": "Reminding the steep downhill road ahead",
+        "q0928_o4": "Reminding continuous two or more up slopes ahead"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0929": {
+      "prompt": "What does this sign mean?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0929_o1": "Reminding continuous two or more up slopes ahead",
+        "q0929_o2": "Reminding the steep uphill road ahead",
+        "q0929_o3": "Reminding the steep downhill road ahead",
+        "q0929_o4": "Reminding continuous two or more down slopes ahead"
+      },
+      "localeCorrectOptionKey": "D"
+    },
+    "q0930": {
+      "prompt": "These signs warn the driver danger ahead and passing with care.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0931": {
+      "prompt": "This sign warns the driver to run slowly with care and beware of the vehicles from horizontal road.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0932": {
+      "prompt": "This sign means a Y-shaped intersection ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0933": {
+      "prompt": "This sign warns obstacles ahead and reducing speed to bypass.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0934": {
+      "prompt": "This sign warns a sharp left curve ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0935": {
+      "prompt": "This sign warns slippery road ahead and running slowly with care.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0936": {
+      "prompt": "This sign warns two neighboring inverse curves ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0937": {
+      "prompt": "This sign reminds the width of the bridge narrows ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0938": {
+      "prompt": "This sign reminds the lane or the road narrows on the right side ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0939": {
+      "prompt": "This sign reminds the lane or the road narrows on the left side ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0940": {
+      "prompt": "This sign reminds the lane or the road narrows on both sides ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0941": {
+      "prompt": "This sign reminds the road in front changes to inseparate two ways section.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0942": {
+      "prompt": "This sign warns the driver there is a crosswalk ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0943": {
+      "prompt": "This sign warns the driver there is school area ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0944": {
+      "prompt": "This sign warns the driver there have traffic lights ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0945": {
+      "prompt": "This sign reminds dangerous hillside road ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0946": {
+      "prompt": "This sign reminds strong side wind ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0947": {
+      "prompt": "This sign reminds a sharp curve ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0948": {
+      "prompt": "This sign reminds embankment road ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0949": {
+      "prompt": "This sign reminds the road ahead goes through the village or town.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0950": {
+      "prompt": "This sign reminds there is a one-way and poor lighting culvert ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0951": {
+      "prompt": "This sign reminds there is a ferry ahead for vehicles.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0952": {
+      "prompt": "This sign reminds serious bump road ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0953": {
+      "prompt": "This sign reminds bump road ahead which may causes bump phenomenon.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0954": {
+      "prompt": "This sign reminds overflowing road or overflowing bridge ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0955": {
+      "prompt": "This sign reminds an unmanned level crossing ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0956": {
+      "prompt": "This sign reminds an unmanned level crossing ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0957": {
+      "prompt": "This sign reminds the lane for non-motorized vehicles ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0958": {
+      "prompt": "This sign indicates jammed section ahead and passing slowly.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0959": {
+      "prompt": "This sign indicates construction section ahead and bypassing from left or right side.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0960": {
+      "prompt": "This sign indicates obstacle ahead and bypassing from left side.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0961": {
+      "prompt": "This sign indicates one-way section ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0962": {
+      "prompt": "This sign indicates landslide section ahead and bypassing.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0963": {
+      "prompt": "This sign indicates running slowly or stopping to let the vehicle on main road go first.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0964": {
+      "prompt": "This sign means the opposite vehicle should stop to yield when crossing each other.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0965": {
+      "prompt": "This sign indicates indoor car park here.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0966": {
+      "prompt": "This sign indicates indoor car park here.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0967": {
+      "prompt": "The yellow lane-dividing line in the picture is used to separate the traffic flow in opposite directions, crossing the line to overtake or make a turn is allowed if it is safe.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0968": {
+      "prompt": "This sign indicates intersection ahead.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0969": {
+      "prompt": "The double yellow solid lines in the middle of the road are used to separate the traffic flow in opposite directions, crossing the lines to overtake or make a turn is allowed if it is safe.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    },
+    "q0970": {
+      "prompt": "When a vehicle is being overtaken by another vehicle, and there is a vehicle following behind, the driver should _____.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0970_o1": "continue to speed up and run",
+        "q0970_o2": "turn slightly to the right side, keep a safe horizontal distance",
+        "q0970_o3": "run by road center",
+        "q0970_o4": "speed up to the right side to yield"
+      },
+      "localeCorrectOptionKey": "B"
+    },
+    "q0971": {
+      "prompt": "For a driver who drives a commercial motor vehicle after drinking, besides revoking his/her driving license, how long will he/she be banned from re-obtaining a motor vehicle driving license?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0971_o1": "1 year",
+        "q0971_o2": "2 year",
+        "q0971_o3": "5 year",
+        "q0971_o4": "10 year"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0972": {
+      "prompt": "For a driver who drivers a commercial motor vehicle after drinking, besides being detained by the traffic management department of the public security organ till he/she sobers up, what will he/she be subject to?",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready",
+      "options": {
+        "q0972_o1": "Temporary detainment of the motor vehicle",
+        "q0972_o2": "Temporary detainment of the driving license",
+        "q0972_o3": "Revocation of the motor vehicle driving license",
+        "q0972_o4": "He/she will be banned from driving for life"
+      },
+      "localeCorrectOptionKey": "C"
+    },
+    "q0973": {
+      "prompt": "When driving a motor vehicle after drinking, a prison term of more than 3 years will be imposed.",
+      "explanation": "",
+      "sourceMode": "original-pdf-text-extract",
+      "confidence": "high",
+      "reviewStatus": "ready"
+    }
+  }
+}

--- a/scripts/build-original-test-language.py
+++ b/scripts/build-original-test-language.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+DEV / BUILD-TIME MAINTENANCE TOOL — NOT part of the app, never bundled or shipped.
+
+Regenerates  public/qbank/2023-test1/translations.en-orig.json , the question
+language shown in-app as "British Chinglish, (original test version)".
+
+What it does:
+  - Reads the ORIGINAL question wording straight from the text layer of
+    raw/2023 Driving test 1.pdf  (questions 1-973), column reading-order.
+  - Maps each onto the English master qbank (questions.json) by question number.
+  - Writes one translation entry per master question that exists in the PDF.
+    Questions NOT in this PDF (numbers 974+, and the de-duplicated 431/450/518/906)
+    get no entry and fall back to English in the app.
+
+What it deliberately does NOT do:
+  - It never stores answers/categories/images. The app inherits those from the
+    master (questions.json), so the answer key is always the master's — even where
+    the PDF itself staged a wrong answer.
+  - It never touches questions.json (human-locked master).
+
+Run it again only if the master qbank changes and you want to refresh this language:
+    pip install pdfplumber
+    python3 scripts/build-original-test-language.py
+"""
+import json, re, os, datetime
+import pdfplumber
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+QBANK = os.path.join(ROOT, "public", "qbank", "2023-test1")
+PDF = os.path.join(ROOT, "raw", "2023 Driving test 1.pdf")
+OUT = os.path.join(QBANK, "translations.en-orig.json")
+
+NUM = re.compile(r"^\s*(\d{1,4})\s*[.、,]\s*(.*)$")
+OPT = re.compile(r"^\s*([A-D])\s*[.、,]\s*(.*)$")
+ANS = re.compile(r"^\s*Answer\s*[:：]\s*(.*)$", re.I)
+PAGENUM = re.compile(r"^\s*\d{1,3}\s*$")  # standalone page-number lines to drop
+
+
+def collapse(s):
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def parse_block(body, is_mcq):
+    """Split a question's lines into (prompt, [(letter, text), ...])."""
+    prompt_lines, options = [], []
+    cur, buf, in_opts = None, [], False
+
+    def flush():
+        nonlocal cur, buf
+        if cur is not None:
+            options.append((cur, collapse(" ".join(buf))))
+        cur, buf = None, []
+
+    for line in body:
+        m = OPT.match(line) if is_mcq else None
+        if m:
+            in_opts = True
+            flush()
+            cur, buf = m.group(1), [m.group(2)]
+        elif in_opts:
+            buf.append(line)
+        else:
+            prompt_lines.append(line)
+    flush()
+    return collapse(" ".join(prompt_lines)), options
+
+
+def extract_pdf(pdf_path):
+    """Return {question_number: {'prompt': str, 'options': [(letter, text), ...]}}."""
+    pdf = pdfplumber.open(pdf_path)
+    stream = []
+    for page in pdf.pages:
+        for x0, x1 in ((0, 300), (300, page.width)):  # left column, then right column
+            text = page.within_bbox((x0, 0, x1, page.height)).extract_text() or ""
+            for line in text.split("\n"):
+                if not PAGENUM.match(line):
+                    stream.append(line)
+
+    questions, buf = {}, []
+    for line in stream:
+        answer = ANS.match(line)
+        if not answer:
+            buf.append(line)
+            continue
+        # buf now holds one question's lines; finalize it at the "Answer:" delimiter
+        nidx = next((i for i, l in enumerate(buf) if NUM.match(l)), None)
+        if nidx is not None:
+            m = NUM.match(buf[nidx])
+            num = int(m.group(1))
+            body = [m.group(2)] + buf[nidx + 1:]
+            is_mcq = any(OPT.match(l) for l in body)
+            prompt, options = parse_block(body, is_mcq)
+            questions[num] = {"prompt": prompt, "options": options}
+        buf = []
+    return questions
+
+
+def main():
+    master = json.load(open(os.path.join(QBANK, "questions.json")))["questions"]
+    extracted = extract_pdf(PDF)
+
+    out, mcq, row = {}, 0, 0
+    for mq in master:
+        e = extracted.get(mq["number"])
+        if not e or not e.get("prompt"):
+            continue  # not in this PDF -> English fallback in the app
+        entry = {
+            "prompt": e["prompt"],
+            "explanation": "",
+            "sourceMode": "original-pdf-text-extract",
+            "confidence": "high",
+            "reviewStatus": "ready",
+        }
+        if mq["type"] == "mcq":
+            mcq += 1
+            by_letter = {k: t for k, t in e["options"]}
+            entry["options"] = {}
+            for i, mo in enumerate(mq["options"]):
+                letter = mo.get("originalKey") or chr(65 + i)
+                entry["options"][mo["id"]] = (
+                    by_letter.get(letter)
+                    or (e["options"][i][1] if i < len(e["options"]) else mo["text"])
+                )
+            ci = next((i for i, o in enumerate(mq["options"]) if o["id"] == mq["correctOptionId"]), None)
+            if ci is not None:
+                entry["localeCorrectOptionKey"] = mq["options"][ci].get("originalKey") or chr(65 + ci)
+        else:
+            row += 1
+        out[mq["id"]] = entry
+
+    payload = {
+        "meta": {
+            "locale": "en-orig",
+            "label": "British Chinglish, (original test version)",
+            "description": (
+                'Verbatim original question text extracted from the text layer of '
+                '"2023 Driving test 1.pdf". Answers inherited from the English master qbank '
+                '(some PDF-staged answers are wrong). Mapped 1:1 to master by question number; '
+                "master questions not present in this PDF fall back to English."
+            ),
+            "source": {"pdf": "2023 Driving test 1.pdf", "method": "pdfplumber text-layer, column reading-order"},
+            "translatedQuestions": len(out),
+            "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "localeAnswerKeySupport": True,
+        },
+        "questions": out,
+    }
+    with open(OUT, "w") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(f"Wrote {OUT}\n  {len(out)} entries ({mcq} MCQ + {row} ROW)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new selectable question language **"British Chinglish, (original test version)"** that surfaces the verbatim original wording extracted directly from the text layer of `2023 Driving test 1.pdf`.

## What it does
- Maps the original PDF text 1:1 onto the master qbank by question number — **969 entries** (the questions present in the PDF, #1–973).
- **Answers are inherited from the master qbank**, not the PDF — grading already reads master `correctOptionId`/`correctRow`, so the answer is always correct even where the PDF staged a wrong one (e.g. q782: PDF says B, master says A).
- Pinned to the **top** of the profile → Language picker; reuses English UI chrome.
- Treated as a translated-only locale, so the **35 master questions not in this PDF (#974+) are dropped** — a pure original-test view of 969 questions.

## Files
- `public/qbank/2023-test1/translations.en-orig.json` — 969 original-text entries (new)
- `scripts/build-original-test-language.py` — dev-only regenerator from the PDF (never bundled into the app)
- `messages/index.ts`, `lib/i18n/languageOptions.ts`, `lib/qbank/datasets.ts`, `lib/qbank/localeSupport.ts`, `lib/qbank/rowDisplay.ts` — wiring

## Verification
- `tsc --noEmit` clean · `guard-protected-qbank-files` passes (master untouched)
- Merge / answer-inheritance check: Chinglish text shown, master answer grades correctly
- Filter check: en-orig loads exactly 969 questions; the 35 non-PDF questions dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)